### PR TITLE
Update reverse skill tool discovery

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,4 +1,4 @@
-﻿# Reverse Engineering Skills Master Control
+# Reverse Engineering Skills Master Control
 
 本目录收录了一系列逆向工程相关的技能模块，每个子目录是一个独立模块，内含 `SKILL.md` 描述其适用场景、工具链和工作流程。
 
@@ -37,7 +37,7 @@
 | **RE→利用链** | `pwn-chain/` | 从逆向走到可用 exploit：栈/堆/内核 pwn、pwntools、libc-database、CTF 到真实远程的稳定化 |
 | **固件渗透链** | `firmware-pentest/` | OWASP FSTM 九阶段：提取→EMBA 自动化→Firmadyne/QEMU 仿真→AFL++ fuzz→实机利用 |
 | **EDR 绕过逆向** | `edr-bypass-re/` | 红队场景：逆向 EDR 的 hook 表/ETW/AMSI → 直接 syscall / Hell's Gate / 硬件断点 / call stack spoof |
-| **渗透测试工具链** | `pentest-tools/` | Nmap/Nuclei/SQLMap/FFUF/Hashcat 等 20+ 渗透工具，通过 MCP 暴露给 AI |
+| **渗透测试工具链** | `pentest-tools/` | Nmap/Nuclei/SQLMap/FFUF/Hashcat/Pentest Swarm 等 20+ 渗透工具，通过 MCP 暴露给 AI |
 | **图表生成** | `diagram-generator/` | 从自然语言生成 Mermaid/Graphviz/PlantUML 图表（攻击路径图、数据流图、架构图、状态机） |
 | **攻击链编排** | `attack-chain/` | 多阶段攻击路径规划与执行的总指挥；完整渗透、HW 演练、从外网打到域控等跨阶段任务从这里开始 |
 | **LLM/AI 安全测试** | `llm-security/` | OWASP LLM + ASI Top 10：Prompt 注入、工具滥用、记忆投毒、Agent 劫持、系统提示词提取、**Agent 服从性工程** |
@@ -86,7 +86,7 @@
 powershell -NoProfile -ExecutionPolicy Bypass -File "<skill-root>\scripts\bootstrap-reverse.ps1" -Capability @('工具名') -StartServices
 ```
 
-支持的能力：jadx、apktool、frida、idalib-mcp、jshookmcp、anything-analyzer、idapro、r2、rabin2、adb、agent-browser、ghidra-mcp、nmap、proxycat、burpsuite-mcp、binwalk、unblob、emba、firmadyne、qemu-static、pwntools、ropgadget、one_gadget、bindiff、ghidriff、syswhispers3、pe-sieve、garak、pyrit、osv-scanner、trivy、syft、gitleaks、objection、yara、floss
+支持的能力：jadx、apktool、frida、frida-ps、idalib-mcp、jshookmcp、anything-analyzer、idapro、r2、rabin2、adb、agent-browser、ghidra-mcp、nmap、seclists、proxycat、burpsuite-mcp、pentestswarm、binwalk、unblob、emba、firmadyne、qemu-static、pwntools、ropgadget、one_gadget、bindiff、ghidriff、syswhispers3、pe-sieve、garak、pyrit、osv-scanner、trivy、syft、gitleaks、objection、yara、floss
 
 自举完成后会自动刷新 `tool-index`。
 

--- a/skills/pentest-tools/SKILL.md
+++ b/skills/pentest-tools/SKILL.md
@@ -237,6 +237,7 @@ docker run -d -p 8080:8080 ramkansal/pentestmcp
 - [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings) — 各类漏洞 payload
 - [HackTricks](https://book.hacktricks.wiki/) — 渗透技巧百科
 - [pentest-ai-agents](https://github.com/0xSteph/pentest-ai-agents) — 35 个 Claude Code 渗透子 agent（参考其 prompt 模式）
+- [Pentest Swarm AI](https://github.com/Armur-Ai/Pentest-Swarm-AI) — 群体智能自主渗透框架（多 agent 协同，支持 MCP server）
 - [ProxyCat](https://github.com/honmashironeko/ProxyCat) — 代理池中间件（批量扫描防封 IP）
 - [planning-with-files](https://github.com/othmanadi/planning-with-files) — 计划任务 skill（循环测试用）
 

--- a/skills/scripts/lib/ToolDiscovery.ps1
+++ b/skills/scripts/lib/ToolDiscovery.ps1
@@ -1,4 +1,4 @@
-﻿Set-StrictMode -Version Latest
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 function Get-ReverseUserProfilePath {
@@ -47,7 +47,8 @@ function Get-ReverseToolCatalog {
             Name = 'jadx'
             Skill = 'apk-reverse'
             Purpose = 'Java 反编译'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'jadx' },
                 [pscustomobject]@{ Type = 'path'; Value = (Join-Path $userProfile 'Tools\jadx\bin\jadx.bat') }
@@ -57,7 +58,8 @@ function Get-ReverseToolCatalog {
             Name = 'apktool'
             Skill = 'apk-reverse'
             Purpose = 'APK 解包与重建'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'apktool' },
                 [pscustomobject]@{ Type = 'path'; Value = (Join-Path $userProfile 'Tools\apktool\apktool.bat') },
@@ -87,7 +89,8 @@ function Get-ReverseToolCatalog {
             Name = 'apksigner'
             Skill = 'apk-reverse'
             Purpose = 'APK 签名'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'apksigner' }
             )
@@ -96,7 +99,8 @@ function Get-ReverseToolCatalog {
             Name = 'zipalign'
             Skill = 'apk-reverse'
             Purpose = 'APK 对齐'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'zipalign' }
             )
@@ -105,7 +109,8 @@ function Get-ReverseToolCatalog {
             Name = 'frida'
             Skill = 'apk-reverse'
             Purpose = 'Frida 动态注入'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'frida' },
                 [pscustomobject]@{ Type = 'path'; Value = (Join-ReverseOptionalPath -Path $appData -ChildPath 'Python\Python3xx\Scripts\frida.exe') }
@@ -115,7 +120,8 @@ function Get-ReverseToolCatalog {
             Name = 'frida-ps'
             Skill = 'apk-reverse'
             Purpose = 'Frida 进程枚举'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'frida-ps' },
                 [pscustomobject]@{ Type = 'path'; Value = (Join-ReverseOptionalPath -Path $appData -ChildPath 'Python\Python3xx\Scripts\frida-ps.exe') }
@@ -197,7 +203,8 @@ function Get-ReverseToolCatalog {
             Name = 'python'
             Skill = 'reverse-engineering'
             Purpose = '辅助脚本执行'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'python' },
                 [pscustomobject]@{ Type = 'command'; Value = 'python3' }
@@ -207,7 +214,8 @@ function Get-ReverseToolCatalog {
             Name = 'pip'
             Skill = 'reverse-engineering'
             Purpose = 'Python 包管理'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'pip' },
                 [pscustomobject]@{ Type = 'command'; Value = 'pip3' }
@@ -217,7 +225,8 @@ function Get-ReverseToolCatalog {
             Name = 'node'
             Skill = 'js-reverse'
             Purpose = '运行 Node 侧 JS 复现与 MCP 客户端'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'node' }
             )
@@ -226,7 +235,8 @@ function Get-ReverseToolCatalog {
             Name = 'npx'
             Skill = 'js-reverse'
             Purpose = '运行临时 npm 包与 MCP 入口'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'npx' }
             )
@@ -245,7 +255,8 @@ function Get-ReverseToolCatalog {
             Name = 'agent-browser'
             Skill = 'browser-automation'
             Purpose = '浏览器自动化（Playwright）：打开页面、点击、填表、爬取、截图'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'agent-browser' }
             )
@@ -266,7 +277,8 @@ function Get-ReverseToolCatalog {
             Name = 'playwright'
             Skill = 'browser-automation'
             Purpose = 'Playwright 浏览器引擎'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'playwright' },
                 [pscustomobject]@{ Type = 'path'; Value = (Join-ReverseOptionalPath -Path $appData -ChildPath 'npm\playwright.ps1') }
@@ -276,7 +288,8 @@ function Get-ReverseToolCatalog {
             Name = 'proxycat'
             Skill = 'pentest-tools'
             Purpose = '代理池管理与轮换'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'proxycat' }
             )
@@ -293,10 +306,21 @@ function Get-ReverseToolCatalog {
             )
         }
         [pscustomobject]@{
+            Name = 'pentestswarm'
+            Skill = 'pentest-tools'
+            Purpose = '群体智能自主渗透与 MCP 执行'
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
+            Fallbacks = @(
+                [pscustomobject]@{ Type = 'command'; Value = 'pentestswarm' }
+            )
+        }
+        [pscustomobject]@{
             Name = 'nmap'
             Skill = 'pentest-tools'
             Purpose = '端口扫描与服务识别'
-            VersionArgs = @('--version')
+            FixedVersion = 'v0.5.0'
+            VersionArgs = @()
             Fallbacks = @(
                 [pscustomobject]@{ Type = 'command'; Value = 'nmap' },
                 [pscustomobject]@{ Type = 'path'; Value = 'C:\Program Files (x86)\Nmap\nmap.exe' },
@@ -911,4 +935,3 @@ function Get-ReverseToolReport {
         }
     }
 }
-

--- a/skills/scripts/refresh-tool-index.ps1
+++ b/skills/scripts/refresh-tool-index.ps1
@@ -40,6 +40,7 @@ $scriptRefs = @{
     'npx' = @('js-reverse/SKILL.md')
     'jshookmcp' = @('js-reverse/SKILL.md')
     'seclists' = @('pentest-tools/SKILL.md')
+    'pentestswarm' = @('pentest-tools/SKILL.md')
     'agent-browser' = @('browser-automation/SKILL.md')
     'playwright' = @('browser-automation/SKILL.md', 'browser-automation/scripts/setup.ps1')
     'analyzeHeadless' = @('reverse-engineering/SKILL.md')
@@ -78,7 +79,7 @@ $markdownContent = ($markdownLines -join [Environment]::NewLine) + [Environment]
 $markdownContent | Set-Content -LiteralPath $OutputMarkdown -Encoding utf8
 
 # --- Capability status view ---
-$capabilityNames = @('jadx', 'apktool', 'frida', 'idalib-mcp', 'jshookmcp', 'anything-analyzer', 'idapro', 'r2', 'adb', 'agent-browser', 'ghidra-mcp', 'seclists', 'proxycat', 'burpsuite-mcp', 'nmap')
+$capabilityNames = @('jadx', 'apktool', 'frida', 'frida-ps', 'idalib-mcp', 'jshookmcp', 'anything-analyzer', 'idapro', 'r2', 'rabin2', 'adb', 'agent-browser', 'ghidra-mcp', 'seclists', 'proxycat', 'burpsuite-mcp', 'pentestswarm', 'nmap')
 $capabilityRows = @()
 foreach ($capName in $capabilityNames) {
     $state = Get-ReverseCapabilityState -Name $capName


### PR DESCRIPTION
## Summary
- Add pentestswarm/Pentest Swarm AI references to reverse-skill pentest tooling docs.
- Extend tool discovery metadata and supported capability lists for frida-ps, rabin2, seclists, and pentestswarm.
- Update refresh-tool-index capability output to include new tool routing.

## Verification
- `git diff --check -- skills/SKILL.md skills/pentest-tools/SKILL.md skills/scripts/lib/ToolDiscovery.ps1 skills/scripts/refresh-tool-index.ps1`
- `[void][scriptblock]::Create((Get-Content .\skills\scripts\refresh-tool-index.ps1 -Raw)); 'parse ok'`