### PR TITLE
fix(refresh-tool-index): silent exit when version cmd returns non-zero

### DIFF
--- a/skills/scripts/refresh-tool-index.sh
+++ b/skills/scripts/refresh-tool-index.sh
@@ -33,7 +33,7 @@ run_version() {
     echo ""
     return 0
   fi
-  "$cmd" "$@" 2>&1 | head -n 1 | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+  "$cmd" "$@" 2>&1 | head -n 1 | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true
 }
 
 file_exists_any() {


### PR DESCRIPTION
## Problem

`run_version` executes under `set -o pipefail`. If a tool is **present** (`command -v` finds it) but its version command exits non-zero, the pipeline failure propagates through `set -e` and kills the script mid-loop — silently skipping all remaining tools.

Concrete trigger: macOS ships a Java stub at `/usr/bin/java`. It exists, so `has_cmd java` passes, but running `java -version` without a real JDK installed prints an error and exits non-zero. This terminates the script after the first tool, leaving `tool-index.md` with only the header row.

This is a **latent bug** — it only surfaces when a tool is present on PATH but its version command fails. Any similar stub/wrapper (not just Java) can trigger it.

## Fix

Add `|| true` to the pipeline in `run_version` so the function always returns 0:

```bash
- "$cmd" "$@" 2>&1 | head -n 1 | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+ "$cmd" "$@" 2>&1 | head -n 1 | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true
```

This is safe because tool availability (`available=yes/no`) is determined independently via `has_cmd` and path-probe **before** `run_version` is called. The version field is metadata only — silencing a non-zero exit here has no effect on routing or availability detection.