### PR TITLE
Fix reverse skill frontmatter discovery

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,4 +1,9 @@
-﻿# Reverse Engineering Skills Master Control
+---
+name: reverse-skill-router
+description: Routes reverse engineering, exploitation, penetration testing, malware, mobile, firmware, browser automation, documentation, and security tasks to the appropriate specialist skill. Use when a task spans modules or the correct reverse-skill entrypoint is unclear.
+---
+
+# Reverse Engineering Skills Master Control
 
 本目录收录了一系列逆向工程相关的技能模块，每个子目录是一个独立模块，内含 `SKILL.md` 描述其适用场景、工具链和工作流程。
 

--- a/skills/api-security/SKILL.md
+++ b/skills/api-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: api-security
+description: Use for authorized security assessment of REST, GraphQL, WebSocket, or SOAP APIs, including discovery, authentication, authorization, rate-limit, and CI/CD testing.
+---
+
 # API 安全测试
 
 > 覆盖 REST / GraphQL / WebSocket / SOAP 全协议

--- a/skills/attack-chain/SKILL.md
+++ b/skills/attack-chain/SKILL.md
@@ -1,4 +1,9 @@
-﻿# Attack Chain Orchestration Skill
+---
+name: attack-chain
+description: Use for authorized multi-stage attack-path planning and orchestration when a task spans reconnaissance, initial access, privilege escalation, lateral movement, or impact assessment. Route single-stage tasks directly to their specialist skill.
+---
+
+# Attack Chain Orchestration Skill
 
 > 多阶段攻击路径规划与执行的总指挥。当任务需要"从 A 打到 B"的完整链路时，本 Skill 负责编排各阶段、协调子 Skill、规划攻击路径。
 > 不是"红队专属"——任何需要跨阶段组合的渗透场景都从这里开始。

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: browser-automation
 description: |
   统一自动化入口。覆盖浏览器自动化（Playwright）和 Windows 桌面应用自动化（OpenReverse）。

--- a/skills/docs-generator/SKILL.md
+++ b/skills/docs-generator/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: docs-generator
 description: |
   Creates task-oriented technical documentation with progressive disclosure. Use when writing READMEs, API docs, architecture docs, or markdown documentation.

--- a/skills/js-reverse/SKILL.md
+++ b/skills/js-reverse/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: js-reverse
 description: 在使用 js-reverse-mcp 做前端 JavaScript 逆向时使用，适用于签名链路定位、页面观察取证、运行时采样、本地补环境复现与证据化输出。优先适配当前环境里的 js-reverse_* 工具，需要更强的浏览器/CDP/Hook 面时联动 jshookmcp。
 ---

--- a/skills/llm-security/SKILL.md
+++ b/skills/llm-security/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: llm-security
+description: Use for authorized security assessment of LLM applications and AI agents, including prompt injection, tool abuse, RAG exposure, memory poisoning, and model supply-chain risks.
+---
+
 # LLM / AI 安全测试
 
 > 覆盖 OWASP LLM Top 10 v2.0 + OWASP Agentic AI Top 10（ASI 2026）

--- a/skills/malware-analysis/SKILL.md
+++ b/skills/malware-analysis/SKILL.md
@@ -1,4 +1,9 @@
-﻿# Malware Analysis
+---
+name: malware-analysis
+description: Use when analyzing suspected malware through static, dynamic, and behavioral techniques, including IOC extraction, YARA or Sigma rules, sandboxing, and anti-analysis behavior.
+---
+
+# Malware Analysis
 
 > YARA / Sigma / 沙箱 / IOC 提取 / 反反分析
 > 静态 + 动态 + 行为三合一

--- a/skills/mobile-reverse/SKILL.md
+++ b/skills/mobile-reverse/SKILL.md
@@ -1,4 +1,9 @@
-﻿# Mobile Reverse Engineering
+---
+name: mobile-reverse
+description: Use for authorized Android or iOS application reverse engineering and security testing, including APK or IPA analysis, runtime instrumentation, SSL pinning, and platform protection checks.
+---
+
+# Mobile Reverse Engineering
 
 > Android + iOS 统一逆向方法论
 > Frida / Objection / OWASP MSTG / SSL Pinning Bypass

--- a/skills/supply-chain-security/SKILL.md
+++ b/skills/supply-chain-security/SKILL.md
@@ -1,4 +1,9 @@
-﻿# Supply Chain Security Testing
+---
+name: supply-chain-security
+description: Use for software supply-chain security assessment covering SBOM, SCA, CI/CD pipelines, container images, build integrity, dependency provenance, and vulnerability reachability.
+---
+
+# Supply Chain Security Testing
 
 > SBOM / SCA / CI/CD 管道 / 依赖溯源
 > 法规驱动：美国行政令 SBOM、中国国标、EU CRA


### PR DESCRIPTION
## What changed

- Added minimal `name` and `description` YAML frontmatter to seven reverse/security skills.
- Removed UTF-8 BOM prefixes that hid otherwise valid frontmatter in three skills.
- Left all skill bodies and routing logic unchanged.

## Why

Codex skill discovery requires `SKILL.md` to begin at byte zero with a YAML `---` delimiter and contain non-empty `name` and `description` fields. Seven files lacked frontmatter and three placed a BOM before the delimiter, producing startup warnings.

## Impact

All 85 locally installed skills now load with parseable metadata and unique names. The reverse skill router becomes discoverable with a gated routing description.

## Verification

- Parsed all 85 `SKILL.md` frontmatters with Ruby YAML.
- Confirmed all 85 are BOM-free and have unique, non-empty names and descriptions.
- Confirmed normalized bodies of all 10 changed files are identical to `HEAD` before the metadata fix.
- Ran an ephemeral Codex startup smoke test; it returned `SKILL-LOAD-OK` with no frontmatter or affected-path warnings.
- Codex self-review passed and an independent Claude read-only review returned `Proceed` with no blockers.
