### PR TITLE
fix(skills): add Codex frontmatter to dsl-vm-reverse

### DIFF
--- a/skills/reverse-engineering/dsl-vm-reverse/SKILL.md
+++ b/skills/reverse-engineering/dsl-vm-reverse/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dsl-vm-reverse
+description: Reverse JavaScript-based custom DSL/VM interpreters, non-standard WASM-like runtimes, and risk-control engines. Use when analyzing IIFE or switch-based opcode dispatchers, extracting instruction tables, recovering bytecode semantics, capturing VM state at runtime, or reconstructing execution flow.
+---
+
 # 🔄 DSL 自定义虚拟机逆向（DSL VM Reverse Engineering）
 
 > 用于逆向基于 JavaScript 实现的自定义 WASM 虚拟机/风控引擎


### PR DESCRIPTION
## Summary

- add the required YAML frontmatter to the nested `dsl-vm-reverse` skill
- describe its trigger contexts so Codex can discover and route DSL/VM analysis tasks to it
- leave the existing skill body unchanged

## Root cause

The earlier Codex frontmatter cleanup fixed the router and first-level skills, but `skills/reverse-engineering/dsl-vm-reverse/SKILL.md` remained without frontmatter. Codex therefore skips this nested skill and reports a missing YAML frontmatter error when it is discovered.

## Validation

- Codex `skill-creator` `quick_validate.py`: `Skill is valid!`
- `git diff --check`
- verified that the file begins directly with `---` and has no UTF-8 BOM
