### PR TITLE
fix(bootstrap): register PentestSwarm MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Routing: sigma vs malware, LLM 越狱 vs iOS 越狱, 完整渗透/打到域控 vs AD 域控, forensics vs OT ics; master-route.ps1 rewritten UTF-8 BOM for PS 5.1 CJK
+- Linux/macOS bootstrap: register PentestSwarm MCP with a verified executable path after Go install or when already installed
 
 ### Security
 

--- a/skills/scripts/bootstrap-reverse.sh
+++ b/skills/scripts/bootstrap-reverse.sh
@@ -608,18 +608,46 @@ ensure_nmap() {
   case "$PLATFORM" in macos) install_brew nmap ;; linux) install_apt nmap ;; esac
 }
 
+register_pentestswarm_mcp() {
+  local executable="$1"
+  local definition
+  definition=$(python3 - "$executable" <<'PY'
+import json, sys
+print(json.dumps({"command": sys.argv[1], "args": ["mcp", "serve"]}))
+PY
+)
+  write_mcp_server "pentestswarm" "$definition"
+}
+
 ensure_pentestswarm() {
-  if has_cmd pentestswarm; then log_ok "pentestswarm ready"; return 0; fi
+  local pentestswarm_path
+  pentestswarm_path="$(cmd_path pentestswarm)"
+  if [[ -n "$pentestswarm_path" ]]; then
+    register_pentestswarm_mcp "$pentestswarm_path"
+    log_ok "pentestswarm ready"
+    return 0
+  fi
   if ! has_cmd go; then
     case "$PLATFORM" in macos) install_brew go ;; linux) install_apt golang-go ;; esac
   fi
-  if ! go install github.com/Armur-Ai/Pentest-Swarm-AI/cmd/pentestswarm@v0.1.0; then
-    if has_cmd docker; then
-      write_mcp_server "pentestswarm" '{"command":"docker","args":["run","--rm","-i","ghcr.io/armur-ai/pentestswarm:v0.1.0","mcp","serve"]}'
-      log_warn "pentestswarm Go install failed; registered Docker fallback ghcr.io/armur-ai/pentestswarm:v0.1.0"
-    else
-      manual_required pentestswarm "Install Go 1.24+ or Docker, then install Pentest-Swarm-AI and ensure pentestswarm is on PATH."
+  if go install github.com/Armur-Ai/Pentest-Swarm-AI/cmd/pentestswarm@v0.1.0; then
+    local go_bin
+    go_bin="$(go env GOBIN 2>/dev/null || true)"
+    if [[ -z "$go_bin" ]]; then
+      go_bin="$(go env GOPATH 2>/dev/null || true)/bin"
     fi
+    if [[ -x "$go_bin/pentestswarm" ]]; then
+      register_pentestswarm_mcp "$go_bin/pentestswarm"
+      log_ok "pentestswarm installed and registered"
+      return 0
+    fi
+    log_warn "pentestswarm installed but no executable was found in GOBIN/GOPATH; trying Docker fallback"
+  fi
+  if has_cmd docker; then
+    write_mcp_server "pentestswarm" '{"command":"docker","args":["run","--rm","-i","ghcr.io/armur-ai/pentestswarm:v0.1.0","mcp","serve"]}'
+    log_warn "pentestswarm Go install failed or produced no runnable binary; registered Docker fallback ghcr.io/armur-ai/pentestswarm:v0.1.0"
+  else
+    manual_required pentestswarm "Install Go 1.24+ or Docker, then install Pentest-Swarm-AI and ensure pentestswarm is on PATH."
   fi
 }
 


### PR DESCRIPTION
## Summary

- Register the PentestSwarm MCP server after a successful native Go installation.
- Resolve and store the native executable path so GUI-launched MCP clients do not depend on a Go bin directory in PATH.
- Preserve the Docker fallback when no runnable native binary is available.

## Root cause

The Bash bootstrap recorded no MCP server after Go installation. Its Windows counterpart already performed this registration.

## Checks

- `bash -n skills/scripts/bootstrap-reverse.sh`
- `shellcheck -x skills/scripts/bootstrap-reverse.sh`
- Isolated mocked Go-install, existing-command, and Docker-fallback registration paths
