### PR TITLE
fix(security): harden local tool bootstrap and MCP bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - Pin supply-chain floating tags: jshook `@0.3.4`, pentestswarm `v0.1.0`
 - Bootstrap integrity: GitHub zip/jar downloads verify `assetSha256` (manifest) or GitHub API `digest`; mismatch deletes file and fails
 - Pin jadx `v1.5.6` and apktool `v3.0.2` with published SHA256
+- Remove shell evaluation from Kali user-home resolution and pass Frida hosts through argument arrays
+- Write the Burp MCP token atomically with owner-only permissions on POSIX filesystems
+- Reconnect the Burp MCP bridge when Burp starts after the bridge and parse one stdio message per line
+- Enable authentication for bootstrapped Anything Analyzer MCP servers and register the bearer token with supported clients
+- Stop each stale IDA MCP process individually before starting a replacement
 
 
 ### Added

--- a/README_AI.md
+++ b/README_AI.md
@@ -352,13 +352,18 @@ Whether you use Claude Code, Codex CLI, Cursor, Cline, Windsurf, or another code
 ```json
 {
   "mcpServers": {
-    "anything-analyzer": { "url": "http://localhost:23816/mcp" },
+    "anything-analyzer": {
+      "url": "http://localhost:23816/mcp",
+      "headers": { "Authorization": "Bearer <token from local mcp-server-config.json>" }
+    },
     "idapro": { "url": "http://127.0.0.1:13337/mcp" },
     "jshook": { "command": "npx", "args": ["-y", "@jshookmcp/jshook@0.3.4"], "env": { "JSHOOK_BASE_PROFILE": "search" } },
     "burpsuite": { "command": "node", "args": ["<package root>/burp-mcp-full/mcp-bridge.js"] }
   }
 }
 ```
+
+The bootstrap command enables bearer authentication for Anything Analyzer and registers the generated token for supported clients. Manual configurations must include the `Authorization` header shown above.
 
 ### Minimum Prompt Requirements
 

--- a/burp-mcp-full/mcp-bridge.js
+++ b/burp-mcp-full/mcp-bridge.js
@@ -36,8 +36,8 @@ function resolveToken() {
 const BURP_TOKEN = resolveToken();
 const AUTH_HEADERS = BURP_TOKEN ? { 'Authorization': `Bearer ${BURP_TOKEN}` } : {};
 
-// Tool definitions for MCP
 let TOOLS = null;
+let toolsRequest = null;
 
 async function fetchTools() {
   return new Promise((resolve, reject) => {
@@ -58,6 +58,33 @@ async function fetchTools() {
     req.on('error', reject);
     req.end();
   });
+}
+
+function disconnectedResponse(id) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    error: {
+      code: -32000,
+      message: `Burp MCP not connected at ${BURP_HOST}:${BURP_PORT}. Start Burp with the "MCP Full Control" extension loaded, then retry.`
+    }
+  };
+}
+
+async function ensureTools() {
+  if (TOOLS) return TOOLS;
+  if (!toolsRequest) {
+    toolsRequest = fetchTools()
+      .then(tools => {
+        TOOLS = tools;
+        process.stderr.write(`[burp-mcp-bridge] Connected to Burp. ${TOOLS.length} tools available.\n`);
+        return TOOLS;
+      })
+      .finally(() => {
+        toolsRequest = null;
+      });
+  }
+  return toolsRequest;
 }
 
 async function callTool(toolName, params) {
@@ -260,8 +287,7 @@ function getToolParams(name) {
   return schemas[name] || {};
 }
 
-// MCP JSON-RPC handler
-function handleRequest(msg) {
+async function handleRequest(msg) {
   const { method, id, params } = msg;
 
   switch (method) {
@@ -276,18 +302,31 @@ function handleRequest(msg) {
       return null; // No response needed
 
     case 'tools/list':
-      if (!TOOLS) return { jsonrpc: '2.0', id, error: { code: -32000, message: `Burp MCP not connected at ${BURP_HOST}:${BURP_PORT}. Start Burp with the "MCP Full Control" extension loaded, then reconnect.` } };
-      return { jsonrpc: '2.0', id, result: { tools: buildToolDefinitions(TOOLS) } };
+      try {
+        const tools = await ensureTools();
+        return { jsonrpc: '2.0', id, result: { tools: buildToolDefinitions(tools) } };
+      } catch (err) {
+        return disconnectedResponse(id);
+      }
 
     case 'tools/call': {
-      if (!TOOLS) return { jsonrpc: '2.0', id, error: { code: -32000, message: `Burp MCP not connected at ${BURP_HOST}:${BURP_PORT}. Start Burp with the "MCP Full Control" extension loaded, then reconnect.` } };
+      try {
+        await ensureTools();
+      } catch (err) {
+        return disconnectedResponse(id);
+      }
+      if (!params || typeof params.name !== 'string') {
+        return { jsonrpc: '2.0', id, error: { code: -32602, message: 'tools/call requires params.name' } };
+      }
       const toolName = params.name.replace(/^burp_/, '');
       const toolArgs = params.arguments || {};
-      return callTool(toolName, toolArgs).then(result => ({
-        jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }
-      })).catch(err => ({
-        jsonrpc: '2.0', id, error: { code: -1, message: err.message || 'Tool call failed' }
-      }));
+      try {
+        const result = await callTool(toolName, toolArgs);
+        return { jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] } };
+      } catch (err) {
+        TOOLS = null;
+        return { jsonrpc: '2.0', id, error: { code: -1, message: err.message || 'Tool call failed' } };
+      }
     }
 
     default:
@@ -297,44 +336,38 @@ function handleRequest(msg) {
 
 // Main stdio loop
 async function main() {
-  // Try to fetch tools from Burp
   try {
-    TOOLS = await fetchTools();
-    process.stderr.write(`[burp-mcp-bridge] Connected to Burp. ${TOOLS.length} tools available.\n`);
+    await ensureTools();
   } catch (e) {
     process.stderr.write(`[burp-mcp-bridge] WARNING: Cannot connect to Burp at ${BURP_HOST}:${BURP_PORT}. Start Burp first.\n`);
-    TOOLS = null;
   }
 
   const rl = readline.createInterface({ input: process.stdin, terminal: false });
-  let buffer = '';
-
   let pending = 0;
   let stdinClosed = false;
 
-  rl.on('line', async (line) => {
-    buffer += line;
+  rl.on('line', (line) => {
+    if (!line.trim()) return;
     let msg;
     try {
-      msg = JSON.parse(buffer);
-      buffer = '';
+      msg = JSON.parse(line);
     } catch (e) {
-      if (e instanceof SyntaxError) return; // incomplete JSON, wait for more
-      buffer = '';
       process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }) + '\n');
       return;
     }
 
     pending++;
-    try {
-      const response = await handleRequest(msg);
-      if (response) process.stdout.write(JSON.stringify(response) + '\n');
-    } catch (err) {
-      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id ?? null, error: { code: -1, message: err.message || 'Handler error' } }) + '\n');
-    } finally {
-      pending--;
-      if (stdinClosed && pending === 0) process.exit(0);
-    }
+    handleRequest(msg)
+      .then(response => {
+        if (response) process.stdout.write(JSON.stringify(response) + '\n');
+      })
+      .catch(err => {
+        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id ?? null, error: { code: -1, message: err.message || 'Handler error' } }) + '\n');
+      })
+      .finally(() => {
+        pending--;
+        if (stdinClosed && pending === 0) process.exit(0);
+      });
   });
 
   rl.on('close', () => {

--- a/burp-mcp-full/src/main/java/com/burpmcp/McpHttpServer.java
+++ b/burp-mcp-full/src/main/java/com/burpmcp/McpHttpServer.java
@@ -29,9 +29,15 @@ import burp.api.montoya.websocket.extension.ExtensionWebSocket;
 import java.time.ZonedDateTime;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.*;
@@ -67,9 +73,51 @@ public class McpHttpServer extends NanoHTTPD {
         token = token.trim();
         try {
             Path tokenFile = Paths.get(System.getProperty("user.home"), ".burp-mcp-token");
-            Files.write(tokenFile, token.getBytes(StandardCharsets.UTF_8));
+            writeTokenFile(tokenFile, token);
         } catch (IOException ignored) { }
         return token;
+    }
+
+    private void writeTokenFile(Path tokenFile, String token) throws IOException {
+        Set<PosixFilePermission> ownerOnly = EnumSet.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE);
+        boolean supportsPosix = FileSystems.getDefault()
+                .supportedFileAttributeViews()
+                .contains("posix");
+        Path parent = tokenFile.toAbsolutePath().getParent();
+        Path temporaryFile = supportsPosix
+                ? Files.createTempFile(
+                        parent,
+                        ".burp-mcp-token-",
+                        ".tmp",
+                        PosixFilePermissions.asFileAttribute(ownerOnly))
+                : Files.createTempFile(parent, ".burp-mcp-token-", ".tmp");
+        try {
+            Files.writeString(
+                    temporaryFile,
+                    token,
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE);
+            if (supportsPosix) {
+                Files.setPosixFilePermissions(temporaryFile, ownerOnly);
+            }
+            try {
+                Files.move(
+                        temporaryFile,
+                        tokenFile,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(temporaryFile, tokenFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            if (supportsPosix) {
+                Files.setPosixFilePermissions(tokenFile, ownerOnly);
+            }
+        } finally {
+            Files.deleteIfExists(temporaryFile);
+        }
     }
 
     private boolean isAuthorized(IHTTPSession session) {
@@ -1660,4 +1708,3 @@ public class McpHttpServer extends NanoHTTPD {
         resp.addHeader("Vary", "Origin");
     }
 }
-

--- a/burp-mcp-full/test/mcp-bridge.test.js
+++ b/burp-mcp-full/test/mcp-bridge.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { once } = require('node:events');
+const http = require('node:http');
+const net = require('node:net');
+const { spawn } = require('node:child_process');
+const { test } = require('node:test');
+const path = require('node:path');
+
+class LineReader {
+  constructor(stream) {
+    this.lines = [];
+    this.waiters = [];
+    this.buffer = '';
+    stream.setEncoding('utf8');
+    stream.on('data', chunk => {
+      this.buffer += chunk;
+      const parts = this.buffer.split('\n');
+      this.buffer = parts.pop();
+      for (const line of parts) {
+        this.push(line.replace(/\r$/, ''));
+      }
+    });
+  }
+
+  push(line) {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve(line);
+    } else {
+      this.lines.push(line);
+    }
+  }
+
+  next(timeoutMs = 5000) {
+    if (this.lines.length > 0) return Promise.resolve(this.lines.shift());
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const index = this.waiters.indexOf(waiter);
+        if (index >= 0) this.waiters.splice(index, 1);
+        reject(new Error('Timed out waiting for a line'));
+      }, timeoutMs);
+      const waiter = {
+        resolve: line => {
+          clearTimeout(timeout);
+          resolve(line);
+        }
+      };
+      this.waiters.push(waiter);
+    });
+  }
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function close(server) {
+  if (!server) return Promise.resolve();
+  return new Promise(resolve => server.close(() => resolve()));
+}
+
+test('reconnects after Burp starts and handles a later tool call', async () => {
+  const port = await getFreePort();
+  const bridgePath = path.join(__dirname, '..', 'mcp-bridge.js');
+  const bridge = spawn(process.execPath, [bridgePath], {
+    env: {
+      ...process.env,
+      BURP_MCP_HOST: '127.0.0.1',
+      BURP_MCP_PORT: String(port),
+      BURP_MCP_TOKEN: 'test-token'
+    },
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+  const stdout = new LineReader(bridge.stdout);
+  const stderr = new LineReader(bridge.stderr);
+  let server;
+  const requests = [];
+
+  try {
+    const warning = await stderr.next();
+    assert.match(warning, /Cannot connect to Burp/);
+
+    server = http.createServer((request, response) => {
+      if (request.method === 'GET' && request.url === '/tools') {
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify(['proxy_history']));
+        return;
+      }
+
+      let body = '';
+      request.on('data', chunk => { body += chunk; });
+      request.on('end', () => {
+        requests.push(JSON.parse(body));
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ ok: true }));
+      });
+    });
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, '127.0.0.1', resolve);
+    });
+
+    bridge.stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {}
+    }) + '\n');
+    const listResponse = JSON.parse(await stdout.next());
+    assert.equal(listResponse.id, 1);
+    assert.equal(listResponse.result.tools[0].name, 'burp_proxy_history');
+
+    bridge.stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'burp_proxy_history', arguments: { limit: 1 } }
+    }) + '\n');
+    const callResponse = JSON.parse(await stdout.next());
+    assert.equal(callResponse.id, 2);
+    assert.deepEqual(requests[0], { tool: 'proxy_history', params: { limit: 1 } });
+    assert.match(callResponse.result.content[0].text, /"ok": true/);
+  } finally {
+    const childClosed = bridge.exitCode === null && bridge.signalCode === null
+      ? once(bridge, 'close')
+      : Promise.resolve();
+    bridge.stdin.end();
+    bridge.kill();
+    await close(server);
+    await childClosed.catch(() => {});
+  }
+});

--- a/docs/PACKAGE-SECURITY-AUDIT.md
+++ b/docs/PACKAGE-SECURITY-AUDIT.md
@@ -1,6 +1,6 @@
 # reverse-skill 包内安全审计（可执行面）
 
-> 日期：2026-07-18  
+> 日期：2026-08-02
 > 范围：`skills/**/scripts`、`skills/scripts`、`kali/scripts`、`burp-mcp-full` 可执行脚本与 bootstrap 清单  
 > **不含**：`src-hunter` / payloader 等**教学型 payload 文档**（其 DROP/注入样例属方法论，非自动执行）
 
@@ -25,6 +25,17 @@
 | apktool | pin `v3.0.2` + `assetSha256` |
 | bootstrap PS/sh | 下载后 `Assert-DownloadedFileIntegrity` / `verify_sha256`；优先 manifest 哈希，其次 GitHub `digest`；失败删文件并中止 |
 | 未钉哈希的 release | 仍可安装，但 **WARN** 并打印实际 sha256 |
+
+### 2026-08-02 安全修复
+
+| 项 | 修复 |
+|----|------|
+| Kali quick setup | 使用 `getent` 解析 sudo 用户 home，移除 `eval` |
+| Frida process listing | 使用 `frida-ps` 参数数组，移除内联 Python 代码拼接 |
+| Burp MCP token | 使用受限临时文件原子替换，POSIX 文件权限固定为 `0600` |
+| Burp MCP bridge | 按 MCP 换行消息解析，并在 Burp 启动后按需重连 |
+| Anything Analyzer MCP | bootstrap 默认启用 bearer auth，并为 Claude/Codex 注册凭据 |
+| IDA MCP startup | 逐个结束旧进程，避免多 PID 参数展开错误 |
 
 ## 扫描方法
 

--- a/kali/scripts/quick-setup.sh
+++ b/kali/scripts/quick-setup.sh
@@ -167,7 +167,14 @@ banner "配置 MCP 客户端"
 
 # 检测实际用户（sudo 下 $HOME 可能是 /root）
 REAL_USER="${SUDO_USER:-root}"
-REAL_HOME=$(eval echo "~$REAL_USER")
+REAL_HOME="$(getent passwd "$REAL_USER" 2>/dev/null | cut -d: -f6 || true)"
+if [[ -z "$REAL_HOME" || ! -d "$REAL_HOME" ]]; then
+    REAL_USER="root"
+    REAL_HOME="$(getent passwd root 2>/dev/null | cut -d: -f6 || true)"
+fi
+if [[ -z "$REAL_HOME" || ! -d "$REAL_HOME" ]]; then
+    REAL_HOME="/root"
+fi
 
 MCP_CONFIG_DIR="$REAL_HOME/.claude"
 MCP_CONFIG="$MCP_CONFIG_DIR/mcp.json"

--- a/skills/apk-reverse/scripts/frida-run.ps1
+++ b/skills/apk-reverse/scripts/frida-run.ps1
@@ -111,9 +111,13 @@ if ([string]::IsNullOrWhiteSpace($target) -and -not $ListProcesses) {
 $deviceFlag = if ($Usb) { '-U' } else { '-H' }
 
 if ($ListProcesses) {
-    $escapedRemoteHost = $RemoteHost.Replace("'", "''")
-    $pythonFlag = if ($Usb) { 'usb' } else { 'remote-host' }
-    & $pythonExe -c "import frida; manager = frida.get_device_manager(); device = frida.get_usb_device() if '$pythonFlag' == 'usb' else manager.add_remote_device('$escapedRemoteHost'); [print(f'{p.pid}`t{p.name}') for p in device.enumerate_processes()]"
+    $processArgs = @()
+    if ($Usb) {
+        $processArgs += '-U'
+    } else {
+        $processArgs += @('-H', $RemoteHost)
+    }
+    & $fridaPs @processArgs
     exit $LASTEXITCODE
 }
 

--- a/skills/ida-reverse/scripts/start.ps1
+++ b/skills/ida-reverse/scripts/start.ps1
@@ -141,7 +141,12 @@ if ([string]::IsNullOrWhiteSpace($ServerPath)) {
 # 清理旧进程（杀进程树，包括 worker 子进程）
 $old = Get-Process -Name "ida-pro-mcp" -ErrorAction SilentlyContinue
 if (-not $old) { $old = Get-Process -Name "idalib-mcp" -ErrorAction SilentlyContinue }
-if ($old) { taskkill /F /T /PID $old.Id 2>$null | Out-Null; Start-Sleep 2 }
+if ($old) {
+    foreach ($process in @($old)) {
+        & taskkill.exe /F /T /PID $process.Id 2>$null | Out-Null
+    }
+    Start-Sleep 2
+}
 
 # 后台启动
 Start-Process -WindowStyle Hidden -FilePath $ServerPath -ArgumentList "--host 127.0.0.1 --port $Port"

--- a/skills/scripts/bootstrap-reverse.ps1
+++ b/skills/scripts/bootstrap-reverse.ps1
@@ -181,11 +181,32 @@ function Get-AnythingAnalyzerUserDataPaths {
 function Ensure-AnythingAnalyzerMcpConfig {
     param([int]$Port = 23816)
 
+    $token = ''
+    foreach ($userDataPath in Get-AnythingAnalyzerUserDataPaths) {
+        $configPath = Join-Path $userDataPath 'mcp-server-config.json'
+        if (-not (Test-Path -LiteralPath $configPath)) {
+            continue
+        }
+        try {
+            $existing = Get-Content -LiteralPath $configPath -Raw -Encoding utf8 | ConvertFrom-Json
+            if ($existing.authToken) {
+                $token = [string]$existing.authToken
+                break
+            }
+        }
+        catch {
+            $token = ''
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        $token = [guid]::NewGuid().ToString('N')
+    }
+
     $payload = [ordered]@{
         enabled = $true
         port = $Port
-        authEnabled = $false
-        authToken = ''
+        authEnabled = $true
+        authToken = $token
     }
 
     foreach ($userDataPath in Get-AnythingAnalyzerUserDataPaths) {
@@ -195,6 +216,8 @@ function Ensure-AnythingAnalyzerMcpConfig {
         $configPath = Join-Path $userDataPath 'mcp-server-config.json'
         $payload | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $configPath -Encoding utf8
     }
+
+    return $token
 }
 
 function Test-VsBuildToolsInstalled {
@@ -671,11 +694,23 @@ function Ensure-McpServer {
         switch ($target) {
             'Claude' {
                 $config = Get-ClaudeMcpConfig
-                $config.json.mcpServers[$ServerName] = $ServerDefinition
+                $claudeDefinition = @{}
+                foreach ($key in $ServerDefinition.Keys) {
+                    if ($key -ne 'bearer_token_env_var') {
+                        $claudeDefinition[$key] = $ServerDefinition[$key]
+                    }
+                }
+                $config.json.mcpServers[$ServerName] = $claudeDefinition
                 Save-ClaudeMcpConfig -Config $config
             }
             'Codex' {
-                Set-CodexMcpServer -ServerName $ServerName -ServerDefinition $ServerDefinition
+                $codexDefinition = @{}
+                foreach ($key in $ServerDefinition.Keys) {
+                    if ($key -ne 'headers') {
+                        $codexDefinition[$key] = $ServerDefinition[$key]
+                    }
+                }
+                Set-CodexMcpServer -ServerName $ServerName -ServerDefinition $codexDefinition
             }
         }
     }
@@ -722,7 +757,14 @@ function Wait-ForPort {
 }
 
 function Start-AnythingAnalyzerService {
-    param([Parameter(Mandatory = $true)]$Definition)
+    param(
+        [Parameter(Mandatory = $true)]$Definition,
+        [string]$AuthToken = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($AuthToken)) {
+        $AuthToken = Ensure-AnythingAnalyzerMcpConfig -Port ([int]$Definition.servicePort)
+    }
 
     if (Test-ReverseTcpPort -Port ([int]$Definition.servicePort)) {
         return
@@ -759,8 +801,6 @@ if (Test-ReverseIsWindows) {
         }
         $repoDir = $installDir
     }
-
-    Ensure-AnythingAnalyzerMcpConfig -Port ([int]$Definition.servicePort)
 
     $pnpm = Get-NodeCommandPath -Name 'pnpm'
     if ([string]::IsNullOrWhiteSpace($pnpm)) {
@@ -984,9 +1024,22 @@ function Ensure-Capability {
         }
         'local-http-mcp' {
             if ($Name -eq 'anything-analyzer') {
-                Ensure-McpServer -ServerName 'anything-analyzer' -ServerDefinition @{ url = $definition.mcpUrl }
+                $authToken = Ensure-AnythingAnalyzerMcpConfig -Port ([int]$definition.servicePort)
+                $env:ANYTHING_ANALYZER_MCP_TOKEN = $authToken
+                try {
+                    [Environment]::SetEnvironmentVariable('ANYTHING_ANALYZER_MCP_TOKEN', $authToken, 'User')
+                }
+                catch {
+                    Write-Warning "Could not persist ANYTHING_ANALYZER_MCP_TOKEN for future MCP clients: $($_.Exception.Message)"
+                }
+                $serverDefinition = @{
+                    url = $definition.mcpUrl
+                    headers = @{ Authorization = "Bearer $authToken" }
+                    bearer_token_env_var = 'ANYTHING_ANALYZER_MCP_TOKEN'
+                }
+                Ensure-McpServer -ServerName 'anything-analyzer' -ServerDefinition $serverDefinition
                 if ($StartServices) {
-                    Start-AnythingAnalyzerService -Definition $definition
+                    Start-AnythingAnalyzerService -Definition $definition -AuthToken $authToken
                 }
                 return $true
             }


### PR DESCRIPTION
## Summary

This PR addresses the six unclaimed security and reliability findings in #32.

- Replace Kali's shell-evaluated home lookup with a safe passwd database lookup.
- Pass Frida remote hosts to `frida-ps` as process arguments instead of interpolating them into Python source.
- Write the Burp MCP token through a restricted temporary file and atomic replacement, with POSIX permissions set to `0600`.
- Parse MCP stdio one newline-delimited message at a time and retry tool discovery when Burp starts after the bridge.
- Enable bearer authentication in the Anything Analyzer bootstrap and register credentials correctly for Claude and Codex.
- Stop stale IDA MCP processes one PID at a time.
- Add a Node regression test covering late Burp startup and a subsequent tool call.

## Why

The affected paths handled user-controlled values through shell or source interpolation, wrote a bearer token with default POSIX permissions, or cached a failed local service connection permanently. The changes keep values as data, make the token replacement atomic, and keep local MCP services usable after startup order changes.

## Validation

- `node --test burp-mcp-full/test/mcp-bridge.test.js`
- `node --check burp-mcp-full/mcp-bridge.js`
- `node --check burp-mcp-full/test/mcp-bridge.test.js`
- `bash -n kali/scripts/quick-setup.sh`
- Targeted scan confirms the vulnerable patterns are absent.
- `git diff --check`

Java compilation was not available in this macOS environment because no Java runtime is installed. PowerShell parsing was not available because `pwsh` is not installed.

Fixes #32