### PR TITLE
fix(case): keep work artifacts in the analysis project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This repository is a **task skill router** for authorized reverse engineering, m
 Routing order:
 
 1. `skills/MASTER-ROUTING.md` or `skills/scripts/master-route.ps1 -Hint "..."`
-2. `skills/scripts/case-init.ps1` → `work/<case>/scope.md` (must grant auth before ACT)
+2. `skills/scripts/case-init.ps1` → current analysis project's `work/<case>/scope.md` (must grant auth before ACT)
 3. `skills/routing.md` when ambiguous; roles in `skills/ops/role-map.md`
 4. Open PRIMARY `SKILL.md` and execute ACTION REQUIRED
 5. Timeline/workitems + Evidence→Finding→Path (`skills/ops/`)

--- a/skills/MASTER-ROUTING.md
+++ b/skills/MASTER-ROUTING.md
@@ -17,8 +17,11 @@
 
 ```powershell
 powershell -File skills\scripts\master-route.ps1 -Hint "<用户任务>"
-# 默认写出 work/master-route-<ts>/route-scope.md
+# 默认写出当前项目的 work/master-route-<ts>/route-scope.md；从其他目录调用时显式指定项目根
+powershell -File skills\scripts\master-route.ps1 -Hint "<用户任务>" -ProjectRoot "C:\path\to\analysis-project"
 powershell -File skills\scripts\case-init.ps1 -Hint "<用户任务>" -CaseName "my-case"
+# case 默认写入当前项目的 work/<case>/；-PackageRoot 保持兼容，-ProjectRoot 优先级更高
+powershell -File skills\scripts\case-init.ps1 -Hint "<用户任务>" -CaseName "my-case" -ProjectRoot "C:\path\to\analysis-project"
 # 一次成型可 ACT（授权 + 目标 + 网络档）：
 powershell -File skills\scripts\case-init.ps1 -Hint "<任务>" -CaseName "my-case" -AuthGranted -TargetUrl "https://target/" -NetworkProfile authorized_target_only
 # 冒烟：verify + 脚本解析 + 路由矩阵（含中文 Hint）

--- a/skills/ops/scope-contract.md
+++ b/skills/ops/scope-contract.md
@@ -8,7 +8,8 @@
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File skills\scripts\case-init.ps1 -Hint "<任务一句话>" -CaseName "my-case"
-# 产出：work/<case>/scope.md 等
+# 默认产出：当前分析项目的 work/<case>/scope.md 等
+# 从其他目录调用 skill 时显式指定：-ProjectRoot "C:\path\to\analysis-project"
 ```
 
 ## scope.md 完整模板

--- a/skills/scripts/case-init.ps1
+++ b/skills/scripts/case-init.ps1
@@ -8,6 +8,7 @@ param(
     [string] $Hint = '',
     [string] $CaseName = '',
     [string] $PackageRoot = '',
+    [string] $ProjectRoot = '',
     [switch] $AuthGranted,
     [string] $AuthStatus = '',
     [string] $AuthBasis = 'own_system',
@@ -23,6 +24,15 @@ $scriptDir = $PSScriptRoot
 if (-not $scriptDir) { $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path }
 $skillsRoot = Split-Path -Parent $scriptDir
 if (-not $PackageRoot) { $PackageRoot = Split-Path -Parent $skillsRoot }
+. (Join-Path (Join-Path $scriptDir 'lib') 'WorkRoot.ps1')
+$requestedProjectRoot = if (-not [string]::IsNullOrWhiteSpace($ProjectRoot)) {
+    $ProjectRoot
+} elseif ($PSBoundParameters.ContainsKey('PackageRoot')) {
+    $PackageRoot
+} else {
+    ''
+}
+$projectRoot = Resolve-ReverseProjectRoot -RequestedRoot $requestedProjectRoot
 
 if (-not $CaseName) {
     $slug = if ($Hint) {
@@ -32,7 +42,7 @@ if (-not $CaseName) {
     $CaseName = '{0}-{1}' -f (Get-Date -Format 'yyyyMMdd-HHmmss'), $slug
 }
 
-# CaseName is a directory name, not a path. Keep every case under PackageRoot/work.
+# CaseName is a directory name, not a path. Keep every case under projectRoot/work.
 # The pattern allows localized names but excludes Windows path syntax and names that
 # Windows would normalize into a dot segment (for example, '.. ' or 'case.').
 if ([string]::IsNullOrWhiteSpace($CaseName) -or
@@ -41,7 +51,8 @@ if ([string]::IsNullOrWhiteSpace($CaseName) -or
     throw "Invalid -CaseName '$CaseName'. Use a 1-80 character directory name beginning with a letter or number; path separators, dot segments, trailing dots/spaces, control characters, and wildcard characters are not allowed."
 }
 
-$caseRoot = Join-Path $PackageRoot ("work\{0}" -f $CaseName)
+$workRoot = Join-Path $projectRoot 'work'
+$caseRoot = Join-Path $workRoot $CaseName
 $dirs = @('evidence', 'notes', 'report')
 New-Item -ItemType Directory -Force -Path $caseRoot | Out-Null
 foreach ($d in $dirs) {
@@ -166,6 +177,7 @@ $scope = @"
 - case_id: $CaseName
 - created: $created
 - operator: local
+- project_root: $projectRoot
 - primary_skill: $primary
 - primary_id: $primaryId
 - lead_role: lead
@@ -288,6 +300,7 @@ $readmeNext
 [System.IO.File]::WriteAllText((Join-Path $caseRoot 'README.md'), $readme, $utf8)
 
 Write-Host ("CASE -> {0}" -f $caseRoot) -ForegroundColor Green
+Write-Host ("PROJECT -> {0}" -f $projectRoot)
 Write-Host ("PRIMARY skill: skills/{0} ({1})" -f $primary, $primaryId)
 Write-Host ("auth.status={0} network_profile={1} ready_for_act={2}" -f $authStatusResolved, $networkMode, $readyStr)
 if ($ready) {

--- a/skills/scripts/lib/WorkRoot.ps1
+++ b/skills/scripts/lib/WorkRoot.ps1
@@ -1,0 +1,33 @@
+Set-StrictMode -Version Latest
+
+function Resolve-ReverseProjectRoot {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$RequestedRoot = ''
+    )
+
+    $root = if ([string]::IsNullOrWhiteSpace($RequestedRoot)) {
+        (Get-Location).ProviderPath
+    } else {
+        $RequestedRoot
+    }
+
+    if ([string]::IsNullOrWhiteSpace($root)) {
+        throw 'Unable to resolve the analysis project root.'
+    }
+
+    if (-not (Test-Path -LiteralPath $root)) {
+        New-Item -ItemType Directory -Force -Path $root | Out-Null
+    }
+    if (-not (Test-Path -LiteralPath $root -PathType Container)) {
+        throw "Project root is not a directory: $root"
+    }
+
+    $item = Get-Item -LiteralPath $root
+    if ($item.PSProvider.Name -ne 'FileSystem') {
+        throw "Project root must use the FileSystem provider: $root"
+    }
+
+    return $item.FullName
+}

--- a/skills/scripts/master-route.ps1
+++ b/skills/scripts/master-route.ps1
@@ -2,7 +2,8 @@
 # reverse-skill PRIMARY router. EN + ZH keyword patterns; UTF-8 BOM source for Windows PowerShell 5.1.
 param(
     [string] $Hint = '',
-    [string] $OutDir = ''
+    [string] $OutDir = '',
+    [string] $ProjectRoot = ''
 )
 $ErrorActionPreference = 'Stop'
 
@@ -187,15 +188,13 @@ $scriptDir = $PSScriptRoot
 if (-not $scriptDir) { $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path }
 $skillsRoot = Split-Path -Parent $scriptDir
 $packageRoot = Split-Path -Parent $skillsRoot
+. (Join-Path (Join-Path $scriptDir 'lib') 'WorkRoot.ps1')
+$projectRoot = Resolve-ReverseProjectRoot -RequestedRoot $ProjectRoot
 
 if ([string]::IsNullOrWhiteSpace($OutDir)) {
     $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-    if ($packageRoot -and (Test-Path -LiteralPath $packageRoot)) {
-        $OutDir = Join-Path $packageRoot ("work\master-route-{0}" -f $stamp)
-    } else {
-        $tmpBase = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-        $OutDir = Join-Path $tmpBase ("reverse-skill-route\master-route-{0}" -f $stamp)
-    }
+    $workRoot = Join-Path $projectRoot 'work'
+    $OutDir = Join-Path $workRoot ("master-route-{0}" -f $stamp)
 }
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
@@ -215,6 +214,7 @@ $sb = New-Object System.Text.StringBuilder
 [void]$sb.AppendLine(("- primary_label: {0}" -f $labels[$primary]))
 [void]$sb.AppendLine(("- primary_skill: skills/{0}" -f $primaryPath))
 [void]$sb.AppendLine(("- confidence: {0}" -f $confidence))
+[void]$sb.AppendLine(("- project_root: {0}" -f $projectRoot))
 $sec = New-Object System.Collections.Generic.List[string]
 foreach ($d in $uniq) {
     if ($d -ne $primary) { [void]$sec.Add(("skills/{0}" -f $map[$d])) }

--- a/skills/scripts/smoke.ps1
+++ b/skills/scripts/smoke.ps1
@@ -46,6 +46,7 @@ $scripts = @(
     'verify-routing-coherence.ps1',
     'master-route.ps1',
     'case-init.ps1',
+    'lib\WorkRoot.ps1',
     'bootstrap-reverse.ps1',
     'refresh-tool-index.ps1',
     'smoke.ps1',

--- a/skills/scripts/verify-routing-coherence.ps1
+++ b/skills/scripts/verify-routing-coherence.ps1
@@ -37,6 +37,7 @@ $opsFiles = @(
     'MASTER-ROUTING.md',
     'scripts\master-route.ps1',
     'scripts\case-init.ps1',
+    'scripts\lib\WorkRoot.ps1',
     'docs-generator\references\security-report-templates.md',
     'field-journal\_template.md'
 )
@@ -179,6 +180,37 @@ $def = & powershell -NoProfile -ExecutionPolicy Bypass -File $masterRoute -Hint 
 $def | Set-Content (Join-Path $ScratchDir 'default-out.txt') -Encoding UTF8
 if ($def -match 'work[\\/]master-route-') { Ok 'default OutDir under work/' } else { Bad 'default OutDir not under work/' }
 
+# project-root output must stay with the analysis project when the skill is invoked elsewhere
+$projectRoot = Join-Path $ScratchDir 'analysis-project'
+New-Item -ItemType Directory -Force -Path $projectRoot | Out-Null
+$projectRoute = & powershell -NoProfile -ExecutionPolicy Bypass -File $masterRoute `
+    -Hint 'radare2 analyze' -ProjectRoot $projectRoot 2>&1 | Out-String
+$projectWork = Join-Path $projectRoot 'work'
+$projectRouteDirs = @(Get-ChildItem -LiteralPath $projectWork -Directory -Filter 'master-route-*' -ErrorAction SilentlyContinue)
+if ($projectRouteDirs.Count -eq 1 -and (Test-Path (Join-Path $projectRouteDirs[0].FullName 'route-scope.md'))) {
+    Ok 'explicit ProjectRoot keeps route artifacts in analysis project'
+} else {
+    Bad 'explicit ProjectRoot did not receive route artifacts'
+}
+
+$defaultProjectRoot = Join-Path $ScratchDir 'default-analysis-project'
+New-Item -ItemType Directory -Force -Path $defaultProjectRoot | Out-Null
+$previousLocation = Get-Location
+try {
+    Set-Location -LiteralPath $defaultProjectRoot
+    $defaultProjectRoute = & powershell -NoProfile -ExecutionPolicy Bypass -File $masterRoute `
+        -Hint 'radare2 analyze' 2>&1 | Out-String
+} finally {
+    Set-Location -LiteralPath $previousLocation
+}
+$defaultProjectWork = Join-Path $defaultProjectRoot 'work'
+$defaultProjectRoutes = @(Get-ChildItem -LiteralPath $defaultProjectWork -Directory -Filter 'master-route-*' -ErrorAction SilentlyContinue)
+if ($defaultProjectRoutes.Count -eq 1 -and (Test-Path (Join-Path $defaultProjectRoutes[0].FullName 'route-scope.md'))) {
+    Ok 'default route artifacts follow the caller project'
+} else {
+    Bad 'default route artifacts did not follow the caller project'
+}
+
 # case-init real path
 $caseName = 'verify-ops-' + (Get-Date -Format 'HHmmss')
 $ci = & powershell -NoProfile -ExecutionPolicy Bypass -File $caseInit -Hint 'apk jadx reverse' -CaseName $caseName -PackageRoot $packageRoot 2>&1 | Out-String
@@ -193,6 +225,36 @@ if (Test-Path (Join-Path $caseRoot 'scope.md')) {
     foreach ($k in @('auth', 'network_profile', 'in_scope', 'ready_for_act')) {
         if ($sc -match $k) { Ok "case scope has $k" } else { Bad "case scope missing $k" }
     }
+}
+
+$projectCaseName = 'verify-project-root-' + (Get-Date -Format 'HHmmss')
+& powershell -NoProfile -ExecutionPolicy Bypass -File $caseInit `
+    -Hint 'apk jadx reverse' -CaseName $projectCaseName -PackageRoot $packageRoot `
+    -ProjectRoot $projectRoot 2>&1 | Out-Null
+$projectCaseRoot = Join-Path $projectWork $projectCaseName
+if ((Test-Path (Join-Path $projectCaseRoot 'scope.md')) -and
+    (Test-Path (Join-Path $projectCaseRoot 'timeline.md')) -and
+    (Test-Path (Join-Path $projectCaseRoot 'workitems.md'))) {
+    Ok 'explicit ProjectRoot keeps case artifacts in analysis project'
+} else {
+    Bad 'explicit ProjectRoot did not receive case artifacts'
+}
+
+$defaultCaseName = 'verify-default-project-' + (Get-Date -Format 'HHmmss')
+try {
+    Set-Location -LiteralPath $defaultProjectRoot
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $caseInit `
+        -Hint 'apk jadx reverse' -CaseName $defaultCaseName 2>&1 | Out-Null
+} finally {
+    Set-Location -LiteralPath $previousLocation
+}
+$defaultCaseRoot = Join-Path (Join-Path $defaultProjectRoot 'work') $defaultCaseName
+if ((Test-Path (Join-Path $defaultCaseRoot 'scope.md')) -and
+    (Test-Path (Join-Path $defaultCaseRoot 'timeline.md')) -and
+    (Test-Path (Join-Path $defaultCaseRoot 'workitems.md'))) {
+    Ok 'default case artifacts follow the caller project'
+} else {
+    Bad 'default case artifacts did not follow the caller project'
 }
 
 # ghost dsl


### PR DESCRIPTION
## Summary

- Default route and case artifacts now follow the caller's analysis project instead of the skill package.
- Add `-ProjectRoot` for deterministic output when the skill is invoked from another directory; preserve `-PackageRoot` compatibility.
- Add regression coverage for explicit and caller-directory roots, plus PowerShell parsing/coherence checks.

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/verify-routing-coherence.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/smoke.ps1`

Closes #45