### PR TITLE
feat(ctf): add ZIP ZipCrypto known-plaintext workflow

### DIFF
--- a/CTF-Sandbox-Orchestrator/README.md
+++ b/CTF-Sandbox-Orchestrator/README.md
@@ -53,6 +53,7 @@
 - Reverse / Pwn / Malware / Firmware / PCAP / 自定义协议重放
 - Windows / AD / Kerberos / DPAPI / 证书滥用 / Relay / Mailbox
 - Android / iOS / Crypto / Stego / Mobile Runtime
+- ZIP / PKZIP legacy encryption / `bkcrack` known-plaintext recovery
 
 ## 仓库结构
 

--- a/CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md
+++ b/CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: competition-zip-archive
+description: Internal downstream skill for ctf-sandbox-orchestrator. CTF-sandbox workflow for ZIP and PKZIP archive challenges, legacy ZipCrypto identification, known-plaintext recovery with bkcrack, key-based decryption, and reproducible extraction. Use when the user asks to solve an encrypted ZIP challenge, inspect ZipCrypto metadata, recover keys from a known file prefix, or unlock an archive without starting with password brute force. Use only after `$ctf-sandbox-orchestrator` has already established sandbox assumptions and routed here.
+---
+
+# Competition ZIP Archive
+
+Use this skill only as a downstream specialization after `$ctf-sandbox-orchestrator` is active and has established sandbox assumptions, evidence priorities, and the analysis project root. If that has not happened yet, return to `$ctf-sandbox-orchestrator` first.
+
+Use this skill when the decisive path is an encrypted ZIP/PKZIP archive rather than an upload parser or a generic crypto blob. Prefer the legacy ZipCrypto known-plaintext path when the challenge gives a predictable file, format header, template, or other recoverable plaintext. Do not begin with blind password brute force.
+
+Reply in Simplified Chinese unless the user explicitly requests English. Keep commands and tool output in their original form.
+
+## Quick Start
+
+1. Preserve the original archive, compute a hash, and work on a copy under the analysis project's `work/<case>/` directory.
+2. Confirm the actual archive format and list entries before attempting a password attack.
+3. Determine whether the entry uses legacy ZipCrypto. `bkcrack` does not recover WinZip AES or other modern encryption.
+4. Build an exact known-plaintext candidate. The attack needs at least 12 known plaintext bytes, including at least 8 contiguous bytes.
+5. Recover the internal keys with `bkcrack`, then create an unencrypted copy and extract it.
+6. Preserve the command, entry names, known-plaintext source, recovered keys, output hash, and final flag as evidence.
+
+## Tool Setup
+
+Use the normal tool index and bootstrap path before guessing an executable location:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/refresh-tool-index.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/bootstrap-reverse.ps1 -Capability bkcrack
+```
+
+On Kali, use the equivalent capability command:
+
+```bash
+bash kali/scripts/bootstrap-reverse.sh bkcrack
+```
+
+The Windows capability is pinned to the `v1.8.1` release and verifies the GitHub asset digest. If the tool is installed manually, refresh `skills/tool-index.md` afterward.
+
+## Workflow
+
+### 1. Establish Archive Truth
+
+Keep the original immutable and record:
+
+```bash
+sha256sum challenge.zip
+file challenge.zip
+bkcrack -L challenge.zip
+```
+
+On Windows, use `Get-FileHash` in place of `sha256sum`. `bkcrack -L` shows entry names, compression methods, and encryption status. Do not infer the encryption type from the `.zip` extension alone.
+
+Check the entry that will provide the known plaintext. A useful candidate is a stored or otherwise predictable file such as a PNG, PDF, text template, or challenge-generated configuration. A local ZIP header (`PK\x03\x04`) is metadata for the archive entry, not plaintext inside the encrypted member, so it is not by itself a useful known-plaintext sample.
+
+### 2. Recover Keys With Known Plaintext
+
+When the ciphertext entry is `flag.txt` and a matching plaintext entry is available in `known.zip`:
+
+```bash
+bkcrack -C challenge.zip -c flag.txt -P known.zip -p flag.txt
+```
+
+For raw ciphertext and plaintext files:
+
+```bash
+bkcrack -c cipherfile -p plainfile
+```
+
+The plaintext must match the bytes represented in the encrypted entry. If the entry was deflated, an uncompressed copy of the file is not automatically the right input; use a matching ZIP fixture or the exact compressed bytes.
+
+If the known bytes begin at an offset, add `-o <offset>`. If only 8-11 bytes are contiguous, combine them with other known bytes using sparse hints:
+
+```bash
+bkcrack -c cipherfile -p plainfile -x 25 4b4f -x 30 21
+```
+
+The successful run yields three internal ZipCrypto keys. Record them exactly as printed; they are not the original password.
+
+### 3. Unlock And Validate
+
+Use the recovered keys to make a new archive, leaving the source untouched:
+
+```bash
+bkcrack -C challenge.zip -k K0 K1 K2 -D unlocked.zip
+7z t unlocked.zip
+7z x unlocked.zip -ounpacked
+```
+
+Replace `K0 K1 K2` with the hexadecimal values printed by `bkcrack`. Validate the output with the archive test command and a hash or exact flag comparison. If only one raw member is needed, `-d` can write its deciphered bytes; deflated raw data may need the `inflate.py` helper shipped with bkcrack.
+
+### 4. Re-route When Preconditions Fail
+
+- WinZip AES or another modern encryption mode: stop this path and identify the challenge-specific primitive.
+- No reliable known plaintext: inspect filenames, metadata, compression choices, challenge source, and other entries before considering password recovery.
+- Known plaintext shorter than the requirement: locate more contiguous bytes or use evidence-backed sparse offsets.
+- The problem is an application upload/parser chain: hand off to `$competition-file-parser-chain`.
+- The problem is a generic ciphertext or custom cipher after archive extraction: hand off to `$competition-crypto-mobile`.
+
+## Evidence To Preserve
+
+- Original and working-copy paths plus SHA-256 hashes
+- `bkcrack -L` output and the selected encrypted member
+- Exact plaintext fixture, compression method, offsets, and sparse byte hints
+- Key recovery command and the three recovered internal keys
+- `unlocked.zip` validation output, extraction path, and final artifact hash
+
+Read `references/zip-archive.md` for the decision table and evidence checklist.

--- a/CTF-Sandbox-Orchestrator/competition-zip-archive/agents/openai.yaml
+++ b/CTF-Sandbox-Orchestrator/competition-zip-archive/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Competition ZIP Archive"
+  short_description: "Solve legacy encrypted ZIP challenges with known plaintext and bkcrack"
+  default_prompt: "After $ctf-sandbox-orchestrator is active, use $competition-zip-archive to identify ZIP encryption, recover ZipCrypto keys with exact known plaintext, unlock a copy, and preserve reproducible evidence."
+
+policy:
+  allow_implicit_invocation: false

--- a/CTF-Sandbox-Orchestrator/competition-zip-archive/references/zip-archive.md
+++ b/CTF-Sandbox-Orchestrator/competition-zip-archive/references/zip-archive.md
@@ -1,0 +1,73 @@
+# ZIP Archive Challenge Reference
+
+## Route Decision
+
+| Observation | Next step |
+|---|---|
+| ZIP/PKZIP archive, legacy encryption, predictable member bytes | Use `bkcrack` known-plaintext recovery |
+| Entry is stored and its file format is known | Build a matching plaintext fixture and attack the entry |
+| Entry is deflated | Match the compressed entry bytes; do not pass an unrelated uncompressed file |
+| WinZip AES or another modern encryption mode | `bkcrack` is not the right primitive; re-route |
+| Upload reaches an application parser or extractor | Use `competition-file-parser-chain` |
+| Archive is only a carrier for hidden media data | Use `competition-stego-media` |
+
+## Minimal Inspection
+
+```text
+file challenge.zip
+bkcrack -L challenge.zip
+7z l -slt challenge.zip
+```
+
+Record the entry name, compression method, encrypted flag, compressed size, uncompressed size, CRC, and any duplicate entries. The ZIP local-file and central-directory signatures are archive metadata; seeing `PK` in the container does not disclose the plaintext of an encrypted member.
+
+## Known-Plaintext Requirements
+
+Legacy ZipCrypto key recovery needs at least 12 known plaintext bytes. At least 8 bytes should be contiguous; more contiguous bytes improve speed and reliability. Good sources include:
+
+- a challenge-provided template or source file;
+- a predictable file signature plus enough fixed header bytes;
+- a known serialized structure with stable fields;
+- a second entry encrypted with the same password and a known exact representation.
+
+For compressed entries, the bytes must correspond to the encrypted data representation. A plaintext ZIP fixture is useful because `bkcrack -P`/`-p` lets the tool read the matching entry representation.
+
+## Command Forms
+
+Archive entry to archive entry:
+
+```bash
+bkcrack -C encrypted.zip -c cipher -P plain.zip -p plain
+```
+
+Raw files, with an offset or sparse bytes when justified by evidence:
+
+```bash
+bkcrack -c cipherfile -p plainfile -o offset
+bkcrack -c cipherfile -p plainfile -x 25 4b4f -x 30 21
+```
+
+Decrypt every compatible entry after key recovery:
+
+```bash
+bkcrack -C encrypted.zip -k 12345678 23456789 34567890 -D unlocked.zip
+```
+
+Decrypt one raw member:
+
+```bash
+bkcrack -c cipherfile -k 12345678 23456789 34567890 -d decipheredfile
+```
+
+Do not publish a command with placeholder keys as if it were a successful solve. Replace them with the values from the actual recovery output and record the source evidence.
+
+## Evidence Checklist
+
+- [ ] Original archive hash recorded before any extraction
+- [ ] Archive type and encryption mode confirmed
+- [ ] Entry name and compression method recorded
+- [ ] Known plaintext bytes and their source explained
+- [ ] At least 12 known bytes, including 8 contiguous bytes, or justified sparse offsets
+- [ ] Key recovery output saved
+- [ ] Decrypted archive tested and extracted from a new path
+- [ ] Final artifact or flag independently validated

--- a/CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/SKILL.md
+++ b/CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/SKILL.md
@@ -69,6 +69,7 @@ If the task is clearly dominated by one domain and the specialized skill exists,
 - `$competition-web-runtime`
 - `$competition-reverse-pwn`
 - `$competition-crypto-mobile`
+- `$competition-zip-archive`
 - `$competition-agent-cloud`
 - `$competition-identity-windows`
 - `$competition-prompt-injection`

--- a/CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/references/crypto-mobile.md
+++ b/CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/references/crypto-mobile.md
@@ -15,6 +15,8 @@ Recover the transform chain in order:
 
 Record exact parameters whenever they matter: keys, IVs, nonces, salts, tags, padding rules, alphabets, offsets, and byte order.
 
+For encrypted ZIP/PKZIP challenges, route to `$competition-zip-archive`. Confirm legacy ZipCrypto first and prefer a known-plaintext attack with `bkcrack`; do not start with blind password brute force. WinZip AES is outside that child skill's scope.
+
 ## Steganography
 
 Inspect metadata, chunk layout, palettes, alpha planes, LSBs, thumbnails, appended trailers, and transcoding artifacts before assuming the payload is absent.

--- a/CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/references/router-matrix.md
+++ b/CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/references/router-matrix.md
@@ -45,6 +45,7 @@ All child `competition-*` skills are downstream-only modules. They should not be
 ### Crypto, Stego, Mobile
 
 - Encoding chain, crypto boundary, stego media, mobile trust boundary -> `$competition-crypto-mobile`
+- Encrypted ZIP/PKZIP, legacy ZipCrypto, known plaintext, `bkcrack` -> `$competition-zip-archive`
 - Image, audio, video, document, trailer, metadata stego -> `$competition-stego-media`
 - Android APK, Frida, signer logic, SSL pinning, native bridge -> `$competition-android-hooking`
 - iOS IPA, Objective-C or Swift runtime, Keychain, pinning, deeplink -> `$competition-ios-runtime`

--- a/kali/scripts/bootstrap-manifest.json
+++ b/kali/scripts/bootstrap-manifest.json
@@ -530,6 +530,15 @@
       "canAutoInstall": true,
       "verifyCommand": "pwntools",
       "kaliNote": "CTF pwn 利用开发框架。Kali 预装，pip 可更新。"
+    },
+    {
+      "name": "bkcrack",
+      "bootstrapKind": "apt-package",
+      "aptPackage": "bkcrack",
+      "docsUrl": "https://github.com/kimci86/bkcrack",
+      "canAutoInstall": true,
+      "verifyCommand": "bkcrack",
+      "kaliNote": "传统 ZipCrypto 已知明文攻击工具；Kali/Debian 可通过 apt 安装。"
     }
   ]
 }

--- a/kali/scripts/bootstrap-reverse.sh
+++ b/kali/scripts/bootstrap-reverse.sh
@@ -29,7 +29,7 @@ for arg in "$@"; do
         --start-services) START_SERVICES=true ;;
         --skip-refresh) SKIP_REFRESH=true ;;
         --list|-l)
-            echo "jadx apktool jeb-pro frida frida-ps idalib-mcp jshookmcp reqable-mcp anything-analyzer idapro r2 rabin2 adb agent-browser ghidra-mcp seclists proxycat burpsuite-mcp nmap pentestswarm"
+            echo "jadx apktool jeb-pro frida frida-ps idalib-mcp jshookmcp reqable-mcp anything-analyzer idapro r2 rabin2 adb agent-browser ghidra-mcp seclists proxycat burpsuite-mcp nmap pentestswarm bkcrack"
             echo "mcp-kali-server metasploitmcp hexstrike-ai adaptixc2 atomic-operator sstimap xsstrike wpprobe fluxion gef coercer evil-winrm-py netexec responder bloodhound certipy"
             exit 0
             ;;
@@ -57,6 +57,9 @@ if [[ ${#CAPABILITIES[@]} -eq 0 ]]; then
     echo "  [MCP 服务]"
     echo "    jshookmcp reqable-mcp anything-analyzer idapro agent-browser"
     echo "    mcp-kali-server metasploitmcp hexstrike-ai pentestswarm"
+    echo ""
+    echo "  [CTF 压缩包]"
+    echo "    bkcrack"
     echo ""
     echo "  [其他]"
     echo "    ghidra-mcp seclists proxycat burpsuite-mcp"
@@ -333,7 +336,7 @@ ensure_capability() {
 
     case "$name" in
         # ─── apt 预装/可装的工具 ───
-        nmap|sqlmap|hashcat|hydra|gobuster|ffuf|adb)
+        nmap|sqlmap|hashcat|hydra|gobuster|ffuf|adb|bkcrack)
             install_apt_package "$name"
             ;;
         msfconsole)

--- a/kali/scripts/lib/tool-discovery.sh
+++ b/kali/scripts/lib/tool-discovery.sh
@@ -51,6 +51,7 @@ declare -a TOOL_CATALOG=(
     "msfconsole|pentest-tools|Metasploit 框架|--version|msfconsole"
     "nikto|pentest-tools|Web 漏洞扫描|-Version|nikto"
     "binwalk|reverse-engineering|固件分析与提取|--help|binwalk"
+    "bkcrack|reverse-engineering|CTF ZIP/PKZIP ZipCrypto 已知明文攻击|--version|bkcrack"
     "gdb|reverse-engineering|调试器|--version|gdb"
     "objdump|reverse-engineering|反汇编|--version|objdump"
     "strings|reverse-engineering|字符串提取|--version|strings"
@@ -120,6 +121,7 @@ declare -A SCRIPT_REFS=(
     ["pentestswarm"]="pentest-tools/SKILL.md"
     ["evil-winrm-py"]="pentest-tools/SKILL.md"
     ["gef"]="reverse-engineering/SKILL.md"
+    ["bkcrack"]="reverse-engineering/crypto-decode-tools.md,../CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md"
     ["netexec"]="pentest-tools/SKILL.md"
     ["responder"]="pentest-tools/SKILL.md"
 )

--- a/kali/scripts/refresh-tool-index.sh
+++ b/kali/scripts/refresh-tool-index.sh
@@ -53,7 +53,7 @@ GENERATED_AT=$(date '+%Y-%m-%d %H:%M:%S %z')
     echo "| 能力 | 工具可用 | MCP 已注册 | 服务在线 | 可自动安装 | 安装方式 |"
     echo "|------|---------|-----------|---------|-----------|---------|"
 
-    CAPABILITY_NAMES=("jadx" "apktool" "jeb-pro" "frida" "idalib-mcp" "jshookmcp" "reqable-mcp" "anything-analyzer" "idapro" "r2" "adb" "agent-browser" "ghidra-mcp" "seclists" "proxycat" "burpsuite-mcp" "nmap" "sqlmap" "hashcat" "hydra" "gobuster" "ffuf" "msfconsole" "nuclei")
+    CAPABILITY_NAMES=("jadx" "apktool" "jeb-pro" "frida" "idalib-mcp" "jshookmcp" "reqable-mcp" "anything-analyzer" "idapro" "r2" "adb" "agent-browser" "ghidra-mcp" "seclists" "proxycat" "burpsuite-mcp" "nmap" "sqlmap" "hashcat" "hydra" "gobuster" "ffuf" "msfconsole" "nuclei" "bkcrack")
 
     for cap_name in "${CAPABILITY_NAMES[@]}"; do
         # 检查工具是否可用

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -37,7 +37,7 @@ description: Routes reverse engineering, exploitation, penetration testing, malw
 | **IDA Pro 逆向** | `ida-reverse/` | IDA Pro MCP HTTP 服务器（72 个工具）：反编译、反汇编、数据流追踪、交叉引用 |
 | **前端 JS 逆向** | `js-reverse/` | 浏览器端签名定位、加密参数分析、运行时采样、Node 补环境复现；优先用现有 `js-reverse_*`，需要更强的浏览器/CDP/Hook 面时接入 jshookmcp，但前提是先把该 MCP server 下载/注册并启用 |
 | **radare2 分析** | `radare2/` | CLI 二进制侦察、反汇编、patch：r2 / rabin2 / rasm2 / radiff2 |
-| **CTF 竞赛全栈** | `../CTF-Sandbox-Orchestrator/` | 40+ 子技能：Web/逆向/Pwn/云/容器/AD/取证/隐写/移动端/密码学，由总控统一编排 |
+| **CTF 竞赛全栈** | `../CTF-Sandbox-Orchestrator/` | 40+ 子技能：Web/逆向/Pwn/云/容器/AD/取证/隐写/移动端/密码学/ZIP，由总控统一编排 |
 | **技术文档编写** | `docs-generator/` | 任务完成后自动生成逆向报告、渗透报告、CTF writeup、签名逆向报告 |
 | **浏览器与桌面自动化** | `browser-automation/` | 浏览器操作（Playwright）+ Windows 桌面应用操作（OpenReverse UIA/CUA）+ 网络观察 |
 | **跨版本符号迁移** | `binary-diff/` | 有旧版符号迁移到新版、缺 PDB 推导、程序更新后批量迁移函数名 |

--- a/skills/reverse-engineering/crypto-decode-tools.md
+++ b/skills/reverse-engineering/crypto-decode-tools.md
@@ -200,7 +200,9 @@ xortool-xor -f encrypted -s "known_plaintext"
 
 6. 如果是 XOR → xortool 分析 key
 
-7. 如果是自定义加密 → IDA/Ghidra 逆向算法 → 手写解密脚本
+7. 如果是传统 ZIP 加密 → 优先使用 `bkcrack` 已知明文攻击，不要先做无证据的密码暴力
+
+8. 如果是自定义加密 → IDA/Ghidra 逆向算法 → 手写解密脚本
 ```
 
 ---

--- a/skills/routing.md
+++ b/skills/routing.md
@@ -55,6 +55,7 @@ Route tasks to the most appropriate skill module by target type, user intent, an
 | Supply chain / SBOM / CI-CD | `supply-chain-security/` — Trivy/Syft/Gitleaks | — |
 | iOS app (IPA) | `mobile-reverse/` — class-dump/Hopper/Frida iOS | `reverse-engineering/platforms.md` |
 | **CTF competition (full stack)** | `../CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/SKILL.md` — master entry | Route to 40+ sub-skills by evidence |
+| **CTF ZIP / PKZIP archive** | `../CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md` — legacy ZipCrypto + `bkcrack` known plaintext | Use before password brute force |
 | Web runtime / API | `../CTF-Sandbox-Orchestrator/competition-web-runtime/SKILL.md` | — |
 | Cloud / Container / K8s | `../CTF-Sandbox-Orchestrator/competition-agent-cloud/SKILL.md` | — |
 | Windows / AD / Identity | `../CTF-Sandbox-Orchestrator/competition-identity-windows/SKILL.md` | — |
@@ -93,6 +94,7 @@ Route tasks to the most appropriate skill module by target type, user intent, an
 | "symbol execution / angr" | `reverse-engineering/tools-dynamic.md` — angr section |
 | "patch environment / Node reproduce" | `js-reverse/references/env-patching.md` |
 | "CTF challenge / competition reverse" | `reverse-engineering/patterns-ctf*.md` |
+| "CTF ZIP / PKZIP / bkcrack / 压缩包明文攻击" | `../CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md` |
 | "write report / documentation" | `docs-generator/` — technical documentation |
 | "write writeup" | `docs-generator/` — CTF writeup template |
 | "open webpage / browser automation / fill form" | `browser-automation/SKILL.md` — Playwright |

--- a/skills/routing_zh.md
+++ b/skills/routing_zh.md
@@ -29,6 +29,7 @@
 | 协议逆向 / 自定义协议 | `reverse-engineering/platforms.md` — 网络协议 | `js-reverse/`（如果是 WebSocket/HTTP） |
 | Go / Rust 二进制 | `reverse-engineering/languages-compiled.md` + `go-reverse.md` | `ida-reverse/` 或 `radare2/` |
 | **CTF 竞赛全栈** | `../CTF-Sandbox-Orchestrator/ctf-sandbox-orchestrator/SKILL.md` — 总控入口 | 按证据面路由到 40+ 子技能 |
+| **CTF ZIP / PKZIP 压缩包题** | `../CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md` — legacy ZipCrypto + `bkcrack` 明文攻击 | 优先于密码暴力破解 |
 | Web 运行时 / API | `../CTF-Sandbox-Orchestrator/competition-web-runtime/SKILL.md` | — |
 | 云 / 容器 / K8s | `../CTF-Sandbox-Orchestrator/competition-agent-cloud/SKILL.md` | — |
 | Windows / AD / 身份 | `../CTF-Sandbox-Orchestrator/competition-identity-windows/SKILL.md` | — |
@@ -65,6 +66,7 @@
 | "模拟执行/Unicorn" | `reverse-engineering/tools.md` — Unicorn 章节 |
 | "补环境/Node 复现" | `js-reverse/references/env-patching.md` |
 | "CTF 题/竞赛逆向" | `reverse-engineering/patterns-ctf*.md` |
+| "CTF ZIP/PKZIP/bkcrack/压缩包明文攻击" | `../CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md` |
 | "写报告/写文档/出报告" | `docs-generator/` — 技术文档编写 |
 | "写 writeup" | `docs-generator/` — CTF writeup 模板 |
 | "打开网页/浏览器自动化/填表" | `browser-automation/SKILL.md` — Playwright 浏览器操作 |

--- a/skills/scripts/bootstrap-manifest.json
+++ b/skills/scripts/bootstrap-manifest.json
@@ -300,6 +300,18 @@
       "docsUrl": "https://github.com/Gallopsled/pwntools",
       "canAutoInstall": true,
       "verifyCommand": "pwntools"
+    },
+    {
+      "name": "bkcrack",
+      "bootstrapKind": "github-release-zip",
+      "repo": "kimci86/bkcrack",
+      "assetRegex": "^bkcrack-1\\.8\\.1-win64\\.zip$",
+      "installDir": "%USERPROFILE%\\Tools\\bkcrack",
+      "docsUrl": "https://github.com/kimci86/bkcrack",
+      "canAutoInstall": true,
+      "verifyCommand": "bkcrack",
+      "releaseTag": "v1.8.1",
+      "preferApiDigest": true
     }
   ]
 }

--- a/skills/scripts/lib/ToolDiscovery.ps1
+++ b/skills/scripts/lib/ToolDiscovery.ps1
@@ -377,6 +377,18 @@ function Get-ReverseToolCatalog {
                 [pscustomobject]@{ Type = 'command'; Value = 'pwn' }
             )
         }
+        [pscustomobject]@{
+            Name = 'bkcrack'
+            Skill = 'reverse-engineering'
+            Purpose = 'CTF ZIP/PKZIP ZipCrypto 已知明文攻击'
+            FixedVersion = 'v1.8.1'
+            VersionArgs = @('--version')
+            Fallbacks = @(
+                [pscustomobject]@{ Type = 'command'; Value = 'bkcrack' },
+                [pscustomobject]@{ Type = 'path'; Value = (Join-Path $userProfile 'Tools\bkcrack\bkcrack.exe') },
+                [pscustomobject]@{ Type = 'path'; Value = 'C:\Tools\bkcrack\bkcrack.exe' }
+            )
+        }
     )
 }
 

--- a/skills/scripts/refresh-tool-index.ps1
+++ b/skills/scripts/refresh-tool-index.ps1
@@ -51,6 +51,7 @@ $scriptRefs = @{
     'binwalk' = @('firmware-pentest/SKILL.md')
     'yara' = @('malware-analysis/SKILL.md')
     'pwntools' = @('reverse-engineering/SKILL.md', 'reverse-engineering/patterns-ctf*.md')
+    'bkcrack' = @('reverse-engineering/crypto-decode-tools.md', '../CTF-Sandbox-Orchestrator/competition-zip-archive/SKILL.md')
 }
 
 $skillsRoot = Split-Path -Parent $PSScriptRoot
@@ -110,7 +111,7 @@ $markdownContent = ($markdownLines -join [Environment]::NewLine) + [Environment]
 $markdownContent | Set-Content -LiteralPath $OutputMarkdown -Encoding utf8
 
 # --- Capability status view ---
-$capabilityNames = @('jadx', 'apktool', 'jeb-pro', 'frida', 'frida-ps', 'idalib-mcp', 'jshookmcp', 'reqable-mcp', 'anything-analyzer', 'idapro', 'r2', 'rabin2', 'adb', 'agent-browser', 'ghidra-mcp', 'seclists', 'proxycat', 'burpsuite-mcp', 'pentestswarm', 'nmap', 'binwalk', 'yara', 'pwntools')
+$capabilityNames = @('jadx', 'apktool', 'jeb-pro', 'frida', 'frida-ps', 'idalib-mcp', 'jshookmcp', 'reqable-mcp', 'anything-analyzer', 'idapro', 'r2', 'rabin2', 'adb', 'agent-browser', 'ghidra-mcp', 'seclists', 'proxycat', 'burpsuite-mcp', 'pentestswarm', 'nmap', 'binwalk', 'yara', 'pwntools', 'bkcrack')
 $capabilityRows = @()
 foreach ($capName in $capabilityNames) {
     $state = Get-ReverseCapabilityState -Name $capName


### PR DESCRIPTION
## Summary

在处理 #45 的 work-root 修复时，顺带补齐 #46 提到的 CTF ZIP/PKZIP 解题能力。

- 新增 downstream `competition-zip-archive` skill，覆盖 ZIP/PKZIP 识别、Legacy ZipCrypto 判断、已知明文攻击、密钥恢复、解密与证据留存。
- 增加中英文路由、CTF 总控路由及加密工具决策，优先已知明文路径，不直接进行无依据的密码暴力破解。
- 增加 Windows 固定版本 `bkcrack v1.8.1` 安装与 digest 校验，以及 Kali apt/bootstrap、工具发现和索引入口。
- 文档覆盖 `-C/-c/-P/-p`、offset、sparse plaintext、`-k`、`-D`，并明确 WinZip AES 不适用。

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/verify-routing-coherence.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/smoke.ps1`
- JSON / PowerShell parsing checks
- Generated tool index contains `bkcrack`
- `git diff --check`

Closes #46