### PR TITLE
fix(case): 兼容 macOS Bash 3.2 的网络配置归一化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,15 @@ jobs:
           bash skills/scripts/case-guard.sh --case-root "$scratch/project/work/network-default"
 
           bash skills/scripts/case-init.sh \
+            --hint "authorized web review" \
+            --case-name "uppercase-network" \
+            --package-root "$scratch/project" \
+            --auth-granted \
+            --network-profile "AUTHORIZED_TARGET_ONLY" \
+            --target-url "https://example.test/"
+          grep -Eq '^- mode: authorized_target_only$' "$scratch/project/work/uppercase-network/scope.md"
+
+          bash skills/scripts/case-init.sh \
             --hint "pending review" \
             --case-name "guard-section" \
             --package-root "$scratch/project" \

--- a/skills/scripts/case-init.sh
+++ b/skills/scripts/case-init.sh
@@ -94,7 +94,8 @@ if [[ -z "$CASE_NAME" || "$case_name_length" -gt 80 ||
   exit 2
 fi
 if [[ -n "$NETWORK_PROFILE" ]]; then
-  case "${NETWORK_PROFILE,,}" in
+  network_profile_normalized="$(printf '%s' "$NETWORK_PROFILE" | tr '[:upper:]' '[:lower:]')"
+  case "$network_profile_normalized" in
     offline|lab_only|authorized_target_only|unrestricted_lab|lab|authorized|auth|offline_only) ;;
     *)
       echo "Invalid --network-profile '$NETWORK_PROFILE'. Allowed: offline, lab_only, authorized_target_only, unrestricted_lab (aliases: lab, authorized, auth, offline_only)." >&2
@@ -146,11 +147,12 @@ elif [[ "$auth_status_resolved" == "granted" && ${#ASSETS[@]} -gt 0 && -z "$SAMP
 else
   network_mode="offline"
 fi
-case "${network_mode,,}" in
+network_mode="$(printf '%s' "$network_mode" | tr '[:upper:]' '[:lower:]')"
+case "$network_mode" in
   lab) network_mode="lab_only" ;;
   authorized|auth) network_mode="authorized_target_only" ;;
   offline_only) network_mode="offline" ;;
-  offline|lab_only|authorized_target_only|unrestricted_lab) network_mode="${network_mode,,}" ;;
+  offline|lab_only|authorized_target_only|unrestricted_lab) ;;
   *)
     echo "Invalid --network-profile '$network_mode'. Allowed: offline, lab_only, authorized_target_only, unrestricted_lab (aliases: lab, authorized, auth, offline_only)." >&2
     exit 2


### PR DESCRIPTION
## 说明

`case-init.sh` 在校验和归一化 `--network-profile` 时使用了 Bash 4 的 `${var,,}`。macOS 自带的 Bash 3.2 执行到该路径会报 `bad substitution`，包括未显式传入网络配置的默认初始化路径。

## 改动

- 使用兼容 Bash 3.2 的 `tr` 完成大小写归一化。
- 保留现有网络配置值、别名和小写规范化输出。
- 在现有 Bash 结构化路由 CI 中增加大写网络配置回归用例。

## 验证

- macOS Bash 3.2：默认初始化成功，并写入 `mode: offline`。
- macOS Bash 3.2：大写 `AUTHORIZED_TARGET_ONLY` 成功初始化，并写入 `mode: authorized_target_only`。
- 现有 Bash 结构化路由测试块通过。
- `bash -n skills/scripts/case-init.sh skills/scripts/master-route.sh skills/scripts/case-guard.sh`
- `git diff --check`
