### PR TITLE
fix(evidence): preserve immutable Evidence records

### DIFF
--- a/skills/scripts/append-evidence.ps1
+++ b/skills/scripts/append-evidence.ps1
@@ -155,7 +155,31 @@ $notesBlock
 "@
 
 $utf8 = New-Object System.Text.UTF8Encoding $false
-[System.IO.File]::WriteAllText($path, $body, $utf8)
+$stream = $null
+$writer = $null
+try {
+    try {
+        $stream = [System.IO.File]::Open(
+            $path,
+            [System.IO.FileMode]::CreateNew,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::None
+        )
+    } catch [System.IO.IOException] {
+        if (Test-Path -LiteralPath $path) {
+            throw ("Evidence record already exists and is immutable: {0}. Use a new -Id." -f $fileName)
+        }
+        throw
+    }
+    $writer = [System.IO.StreamWriter]::new($stream, $utf8)
+    $writer.Write($body)
+} finally {
+    if ($null -ne $writer) {
+        $writer.Dispose()
+    } elseif ($null -ne $stream) {
+        $stream.Dispose()
+    }
+}
 
 $index = Join-Path $evDir 'INDEX.md'
 $line = "- $idSafe | $sev | $st | $titleLine | $fileName"

--- a/skills/scripts/smoke.ps1
+++ b/skills/scripts/smoke.ps1
@@ -121,6 +121,48 @@ if (-not (Test-Path -LiteralPath $mr)) {
 }
 $routeSummary -join [Environment]::NewLine | Set-Content (Join-Path $LogDir '03-route-summary.txt') -Encoding UTF8
 
+# --- 4) Evidence ID immutability ---
+$appendEvidence = Join-Path $scriptDir 'append-evidence.ps1'
+$evidenceCase = Join-Path $LogDir 'evidence-immutability'
+if (-not (Test-Path -LiteralPath $appendEvidence)) {
+    Bad 'append-evidence.ps1 missing for immutability check'
+} else {
+    New-Item -ItemType Directory -Path $evidenceCase -Force | Out-Null
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $appendEvidence `
+        -CaseRoot $evidenceCase `
+        -Id 'E-IMMUTABLE' `
+        -Title 'first write' `
+        -ReproCommand 'echo first' 2>&1 | Out-Null
+    $firstEvidenceExit = $LASTEXITCODE
+    if ($firstEvidenceExit -ne 0) {
+        Bad ("initial Evidence append exit {0}" -f $firstEvidenceExit)
+    } else {
+        $evidencePath = Join-Path $evidenceCase 'evidence\E-IMMUTABLE.md'
+        $indexPath = Join-Path $evidenceCase 'evidence\INDEX.md'
+        $beforeEvidence = (Get-FileHash -LiteralPath $evidencePath -Algorithm SHA256).Hash
+        $beforeIndex = (Get-FileHash -LiteralPath $indexPath -Algorithm SHA256).Hash
+
+        & powershell -NoProfile -ExecutionPolicy Bypass -File $appendEvidence `
+            -CaseRoot $evidenceCase `
+            -Id 'E-IMMUTABLE' `
+            -Title 'second write' `
+            -ReproCommand 'echo second' 2>&1 | Out-Null
+        $duplicateEvidenceExit = $LASTEXITCODE
+
+        $afterEvidence = (Get-FileHash -LiteralPath $evidencePath -Algorithm SHA256).Hash
+        $afterIndex = (Get-FileHash -LiteralPath $indexPath -Algorithm SHA256).Hash
+        if ($duplicateEvidenceExit -eq 0) {
+            Bad 'duplicate Evidence ID was accepted'
+        } elseif ($beforeEvidence -ne $afterEvidence) {
+            Bad 'existing Evidence changed after duplicate append'
+        } elseif ($beforeIndex -ne $afterIndex) {
+            Bad 'Evidence index changed after duplicate append'
+        } else {
+            Ok 'duplicate Evidence ID rejected without mutation'
+        }
+    }
+}
+
 # --- summary ---
 $summary = @(
     "VERIFY_EXIT=$verifyExit",


### PR DESCRIPTION
## Summary

`append-evidence.ps1` currently writes Evidence records with `WriteAllText`, so reusing an existing Evidence ID overwrites the original record and then appends a second row to `INDEX.md`. That conflicts with the repository's Evidence contract, which treats Evidence as immutable observations.

This PR keeps the change bounded to that failure boundary:

- create `E-*.md` with atomic `FileMode.CreateNew` semantics instead of overwrite semantics;
- fail clearly when the normalized Evidence path already exists;
- extend the existing smoke path with a regression that verifies a duplicate ID fails while both the original Evidence file and `INDEX.md` remain byte-for-byte unchanged.

## Validation

The existing Windows/Linux routing matrix already runs `smoke.ps1`, so the regression exercises the real `append-evidence.ps1` entrypoint under native Windows PowerShell 5.1 and the Linux PowerShell shim without adding or changing workflow permissions.