### PR TITLE
ci: exercise shell workflows on macOS system Bash

### DIFF
--- a/.github/workflows/macos-bash-compat.yml
+++ b/.github/workflows/macos-bash-compat.yml
@@ -1,0 +1,70 @@
+name: macOS Bash compatibility
+
+on:
+  pull_request:
+    paths:
+      - 'skills/scripts/**/*.sh'
+      - 'skills/scripts/*.sh'
+      - '.github/workflows/macos-bash-compat.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/scripts/**/*.sh'
+      - 'skills/scripts/*.sh'
+      - '.github/workflows/macos-bash-compat.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  system-bash:
+    name: system Bash compatibility
+    runs-on: macos-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Show system Bash version
+        shell: bash
+        run: /bin/bash --version | head -n 1
+
+      - name: Parse all tracked shell scripts with system Bash
+        shell: bash
+        run: |
+          set -e
+          git ls-files '*.sh' | while IFS= read -r f; do
+            /bin/bash -n "$f"
+            echo "syntax OK: $f"
+          done
+
+      - name: Exercise structured router and case contract
+        shell: bash
+        run: |
+          set -e
+          scratch="$(mktemp -d)"
+          trap 'rm -rf "$scratch"' EXIT
+
+          /bin/bash skills/scripts/master-route.sh \
+            --hint "apk reverse with jadx" \
+            --out-dir "$scratch/route"
+          grep -Eq '^- primary: R1$' "$scratch/route/route-scope.md"
+
+          /bin/bash skills/scripts/case-init.sh \
+            --hint "authorized web review" \
+            --case-name "network-default" \
+            --package-root "$scratch/project" \
+            --auth-granted \
+            --target-url "https://example.test/"
+          grep -Eq '^- mode: authorized_target_only$' "$scratch/project/work/network-default/scope.md"
+          grep -Eq '^- ready_for_act: true$' "$scratch/project/work/network-default/scope.md"
+          /bin/bash skills/scripts/case-guard.sh \
+            --case-root "$scratch/project/work/network-default"
+
+          /bin/bash skills/scripts/case-init.sh \
+            --hint "authorized web review" \
+            --case-name "uppercase-network" \
+            --package-root "$scratch/project" \
+            --auth-granted \
+            --network-profile "AUTHORIZED_TARGET_ONLY" \
+            --target-url "https://example.test/"
+          grep -Eq '^- mode: authorized_target_only$' "$scratch/project/work/uppercase-network/scope.md"


### PR DESCRIPTION
## Summary

The repository documents and supports macOS shell workflows, but the existing CI executes Bash compatibility checks only on Ubuntu. A recent macOS fix (#64) showed why that gap matters: Bash 4-only `${var,,}` syntax passed the Linux path but fails under the system Bash shipped on macOS.

This PR adds one focused macOS compatibility workflow without changing product behavior:

- run only when tracked shell scripts or this workflow change;
- use `/bin/bash` explicitly so the checks exercise the macOS system shell rather than a newer Homebrew Bash;
- parse every tracked `.sh` file with `/bin/bash -n`;
- execute one structured-router path;
- execute the default authorized case-init/case-guard path;
- execute the uppercase network-profile regression that previously exposed the Bash 3.2 incompatibility;
- keep permissions read-only and cap the job at five minutes.

## Why

Ubuntu CI is useful for shell correctness, but it cannot prove compatibility with the older system Bash used by macOS. This keeps that platform contract executable so future shell changes do not silently reintroduce the same class of failure.

## Scope

- CI only
- one new workflow file
- no source changes
- no dependencies
- no route-rule changes
- no overlap with the full Bash routing benchmark in #69
