### PR TITLE
feat(ops): analysis decision framework R1-R51 (#77)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -20,6 +20,8 @@ After reading this file, you MUST NOW (immediately) execute:
 4. NEXT: Initialize case scope (`skills/scripts/case-init.ps1` / `skills/ops/scope-contract.md`). MUST NOT ACT against targets until auth.status=granted and network_profile set
 5. ACT:  Open PRIMARY skill SKILL.md; use roles (`ops/role-map.md`), timeline/workitems, Evidence→Finding→Path (`ops/evidence-finding-path.md`). Identity: `ops/IDENTITY.md` (not a Z3r0 platform clone)
 
+> **Decision quality (Issue #77):** Follow skills/ops/analysis-decision-framework.md for hypothesis exits, validated sufficiency (R4*), grounded conclusions, and deadlock replan. Do **not** paste the full R1-R51 list into this file.
+
 IMPORTANT — Shared installation:
 - tool-index.md is the SINGLE SOURCE OF TRUTH for tool availability
 - If another CLI already installed tools (tool-index shows "yes"), DO NOT reinstall

--- a/RULES_zh.md
+++ b/RULES_zh.md
@@ -144,6 +144,8 @@
 
 ## 执行原则
 
+> **决策质量（Issue #77）：** 假设退出、validated 充分性（R4*）、结论锚定与死锁重规划见 skills/ops/analysis-decision-framework.md。**不要**把 R1-R51 全文塞进本文件。
+
 ### 工具使用
 - **永远不要猜工具路径**，先读 `tool-index.md`
 - 缺少工具时先调用平台对应的 bootstrap 脚本自动补齐，不要直接报错：

--- a/skills/ops/analysis-decision-framework.md
+++ b/skills/ops/analysis-decision-framework.md
@@ -1,0 +1,146 @@
+# Analysis Decision Framework (Issue #77)
+
+> **SSoT role**: Decision-quality / evidence-sufficiency / agent-bias cookbook for reverse-skill agents.
+> **Not** a second master analysis workflow. Obey `re-agent-workflow.md`, feasibility gate (#73), IAT iron rule (#72), A-T / U-AV cookbooks, and `evidence-finding-path.md` first.
+> Rule IDs **R1-R51** keep the reporter numbering (**no R15**; includes **R50/R51**). Do not renumber.
+
+## 0. How to use
+
+| When | Action |
+|------|--------|
+| Finding promotion / Synthesis | **P0** (R4*, R1, R2, R41) |
+| Stage change or stuck loop | R2, R31, R43 |
+| Multi-module / anti-analysis | R50, R51 -> anti-analysis + A-T |
+| Already covered by ops/CI/skills | **P2** pointer only |
+
+**Evidence IDs** (record even on failure):
+
+`E-confidence-low` · `E-hypothesis-confirmed` · `E-hypothesis-rejected` · `E-insufficient-evidence` · `E-negative-evidence` · `E-scope-boundary` · `E-runtime-only` · `E-bias-detected` · `E-over-trust-bias` · `E-module-decoupled` · `E-anti-adversarial` · `ungrounded`
+
+---
+
+## 1. P0 — Full recipes (trigger -> action -> Evidence)
+
+### R1 — Decompile / static confidence band
+
+| | |
+|--|--|
+| **Trigger** | Static decompile/CFG/types as primary reasoning |
+| **Action** | Band `high`/`medium`/`low`. If `low`: MUST schedule dynamic before `validated` |
+| **Evidence** | `E-confidence-low` |
+
+### R2 — Hypothesis-driven stage exit
+
+| | |
+|--|--|
+| **Trigger** | End of triage/static/dynamic or long tool loops |
+| **Action** | State hypothesis; **continue / switch / stop** |
+| **Evidence** | `E-hypothesis-confirmed` or `E-hypothesis-rejected` |
+
+### R3 — Least surprise
+
+Unverified unusual claims MUST be tagged `speculative`.
+
+### R4* — Finding sufficiency (compatible rewrite)
+
+Does **not** replace "Finding binds >=1 Evidence". Tightens **validated** only:
+
+| status | Evidence bar |
+|--------|----------------|
+| preliminary / candidate | >=1 (unchanged) |
+| **validated** | **SHOULD >=2 independent** Evidence (best 1 static + 1 dynamic). Single Evidence MUST NOT silently promote — residual + human, or stay candidate |
+| blocked promotion | `E-insufficient-evidence` |
+
+### R6 — Negative evidence
+
+Checked-absent branch -> `E-negative-evidence`.
+
+### R7 — Analysis boundary
+
+Declare scope limits -> `E-scope-boundary` (align scope-contract).
+
+### R8 — Suspicious != malicious
+
+Default `flavor=null` unless `explicit_malware` / user asks (#71).
+
+### R30 — Runtime back-annotation
+
+Dynamic without static anchor: try relocate; else `E-runtime-only`, Finding <= candidate.
+
+### R31 — Stage bias self-check
+
+Tool/stage fixation -> `E-bias-detected`.
+
+### R41 — Grounded conclusions
+
+Claims MUST map Finding -> Evidence; else `ungrounded`.
+
+### R43 — Plan deadlock -> replan
+
+3 actions with no new Evidence, or 2 stage switches without Evidence -> replan under **feasibility gate**. Aligns RULES Self-Supervision.
+
+### R44 — Single-source high confidence
+
+Cross-check before validated; else `E-over-trust-bias`.
+
+### R50 — Multi-module decoupling
+
+Separate work items -> `E-module-decoupled`.
+
+### R51 — Adversarial effort
+
+Effort band + A-T pointers -> `E-anti-adversarial` (**no** A-T table copy).
+
+---
+
+## 2. P1 — Short rows
+
+| ID | Landing |
+|----|---------|
+| R5 | content_hash; evidence-finding-path + review_case --verify-hashes |
+| R12 | parallel hypotheses via R2 (no heavy case-branch product) |
+| R22 | docs-generator executive summary MUST |
+| R23 | IOC dual-channel **only** explicit_malware / user IOC; forbidden default ordinary RE |
+| R28 | authorized lab; no full weaponized exploit chain in-repo |
+| R34 | SHOULD journal stale note; **no** 90-day auto engine |
+| R36 | archive feedback one-liner |
+| R38-R40 | pointer -> llm-security only |
+| R42 | YARA/detections experimental until benign validation |
+| R45-R49 | route cloud-k8s / firmware / pentest-pwn / code-audit; limit confidence if missing context |
+
+### Downgrades (not Agent runtime MUST)
+
+| ID | Why |
+|----|-----|
+| R16/R19 auto-close PR | CI / human maintainer |
+| R37 MCP gateway product | no in-repo gateway; tool-index + human confirm |
+| R23 unconditional block | conflicts flavor=null |
+| R34 automated stale | no metrics infra |
+
+---
+
+## 3. P2 — Covered elsewhere (index only)
+
+| IDs | SSoT |
+|-----|------|
+| R9-R11 | timeline-workitem, case-init, case-review |
+| R13-R14 + IAT | re-agent-workflow (#67/#72/#73) |
+| R16-R19 (sans auto-close) | smoke, verify, CI, case-review |
+| R20-R21 | evidence-finding-path, append-evidence |
+| R24 | field-journal/anonymization |
+| R25-R26 | skill-supply-chain, bootstrap pin (#76) |
+| R27/R29 | scope-contract, RULES security |
+| R32-R33 | MASTER-ROUTING, role-map |
+| R35 | field-journal |
+| A-T PE anti-analysis | anti-analysis.md |
+| U-AV non-PE | nonpe-format-cookbook.md |
+
+---
+
+## 4. Synthesis checklist
+
+1. R41 grounded claims
+2. R4* validated bar
+3. R1 low confidence -> dynamic
+4. R43 deadlock -> replan under feasibility gate
+5. R8/R23 no default malice/IOC

--- a/skills/ops/evidence-finding-path.md
+++ b/skills/ops/evidence-finding-path.md
@@ -114,3 +114,18 @@ The review is read-only and checks scope fields, Evidence records, work item and
 | PG 不可变行 + API | Markdown 文件 + hash 字段 |
 | UI 审阅队列 | 报告 + next-step 菜单 + journal |
 | ATT&CK 深度绑定 | 可选标签，不强制 UI |
+
+
+## Validated sufficiency (Issue #77 / R4*)
+
+Global bind rule remains: every Finding references **>=1** Evidence.
+
+Promotion to status=validated is stricter (decision cookbook):
+
+| status | Evidence bar |
+|--------|----------------|
+| preliminary / candidate | >=1 (unchanged) |
+| **validated** | **SHOULD >=2 independent** Evidence (best: 1 static + 1 dynamic). A single Evidence item alone MUST NOT silently promote to validated — keep candidate/preliminary, or record residual_risk + human confirm. |
+| blocked promotion | record Evidence E-insufficient-evidence |
+
+Full recipes: [nalysis-decision-framework.md](analysis-decision-framework.md) (R4*, R1, R41, R44).

--- a/skills/reverse-engineering/references/re-agent-workflow.md
+++ b/skills/reverse-engineering/references/re-agent-workflow.md
@@ -193,6 +193,11 @@
 
 ## 4. Synthesis（IOC / 攻击链 / 报告）
 
+### Decision quality overlay (Issue #77)
+
+Before closing Synthesis, apply [nalysis-decision-framework.md](../../ops/analysis-decision-framework.md) **P0 checklist**: R41 grounded claims, R4* validated sufficiency, R1 confidence->dynamic, R2 hypothesis exit, R43 deadlock replan (under feasibility gate), R8/R23 no default malice/IOC. Multi-module -> R50; anti-analysis effort -> R51 + A-T cookbook.
+
+
 ```text
 □ Finding：算法/校验逻辑/可利用点 / 行为结论
 □ Path：callflow 或 solve 步骤挂 E-*

--- a/skills/scripts/verify-routing-coherence.ps1
+++ b/skills/scripts/verify-routing-coherence.ps1
@@ -449,6 +449,23 @@ if ($fail.Count -gt 0) {
     $fail | Set-Content (Join-Path $ScratchDir 'failures.txt') -Encoding UTF8
     exit 1
 }
-Write-Host 'ALL ROUTING COHERENCE CHECKS PASSED' -ForegroundColor Green
+Write-Host '
+# Issue #77 — analysis decision framework anchors
+$adf = Join-Path $PackageRoot "skills\ops\analysis-decision-framework.md"
+Assert-FileExists $adf "analysis-decision-framework.md (issue #77)"
+Assert-FileContains $adf "R4*" "ADF R4* validated sufficiency"
+Assert-FileContains $adf "E-insufficient-evidence" "ADF E-insufficient-evidence"
+Assert-FileContains $adf "E-hypothesis-confirmed" "ADF hypothesis evidence"
+Assert-FileContains $adf "ungrounded" "ADF ungrounded flag"
+Assert-FileContains $adf "Not** a second master" "ADF not second master workflow"
+$efp77 = Join-Path $PackageRoot "skills\ops\evidence-finding-path.md"
+Assert-FileContains $efp77 "analysis-decision-framework" "evidence-finding-path hooks ADF"
+Assert-FileContains $efp77 "E-insufficient-evidence" "evidence-finding-path R4* id"
+$wf77 = Join-Path $PackageRoot "skills\reverse-engineering\references\re-agent-workflow.md"
+Assert-FileContains $wf77 "analysis-decision-framework" "re-agent-workflow hooks ADF"
+$rules77 = Join-Path $PackageRoot "RULES.md"
+Assert-FileContains $rules77 "analysis-decision-framework" "RULES.md hooks ADF"
+
+ALL ROUTING COHERENCE CHECKS PASSED' -ForegroundColor Green
 'ALL ROUTING COHERENCE CHECKS PASSED' | Set-Content (Join-Path $ScratchDir 'verify.txt') -Encoding UTF8
 exit 0


### PR DESCRIPTION
## Summary
Issue #77 reporter agreed **方案 A**. Lands decision-quality cookbook without stuffing 50 rules into RULES SSoT.

- New `skills/ops/analysis-decision-framework.md` — R1–R51 (keep IDs; no R15), P0 full recipes, P1 short, P2 pointers
- **R4***: Finding still ≥1 Evidence; `validated` SHOULD ≥2 independent (or residual+human / `E-insufficient-evidence`)
- Hooks: `evidence-finding-path.md`, `re-agent-workflow.md` §4 Synthesis, `RULES.md` / `RULES_zh.md` one-line pointers
- `verify-routing-coherence.ps1` key anchors
- **Not** second master workflow; feasibility/IAT/A–T/U–AV remain superior
- Downgrades: auto-close PR, MCP gateway product, default IOC block, 90d stale engine
- case-review SKILL hook skipped this PR (tooling path blocked); optional follow-up

## Test plan
- [x] Local smoke + verify ×3 on pwsh and Windows PowerShell 5.1 — ALL PASS
- [ ] CI green
- [ ] Maintainer confirm before merge main

Does not close #77 until maintainer OK after CI.