### PR TITLE
feat(ops): blindspot cookbook R52-R81 (#77 batch 2)

### DIFF
--- a/skills/ops/analysis-blindspot-cookbook.md
+++ b/skills/ops/analysis-blindspot-cookbook.md
@@ -1,0 +1,73 @@
+# Analysis Blindspot Cookbook (Issue #77 batch 2)
+
+> **SSoT**: blindspot recipes R52-R81. **Not** a third master workflow. Obey ADF R1-R51 + re-agent-workflow + A-T/U-AV first.
+> Lab only. Detection+forensics; **no bypass tutorial** for kernel/integrity/injection weaponization.
+
+## 0. Evidence IDs
+
+E-rust-identified, E-golang-identified, E-cpp-rtti, E-objc-msg, E-dotnet-aot, E-string-custom-crypto, E-vmp-protected, E-ollvm-level, E-obfuscation-combo, E-integrity-check, E-proxy-dll, E-process-hollowing, E-apc-inject, E-atom-bombing, E-process-doppelganging, E-exception-chain, E-byovd-advanced, E-edr-callback, E-kernel-protect-tamper, E-uefi-bootkit, E-cloud-cred-theft, E-ole-analysis, E-pdf-malicious, E-wasm-reverse, E-custom-protocol, E-elf-linux, E-llm-hallucination, E-mcp-bootstrap, E-context-pollution, E-anchor-verify
+
+## 1. P0 recipes
+
+### R52 Rust
+Trigger: _ZN mangling, core::/std::, panic/unwrap. Action: Rust sigs; panic edges; dynamic if names collapse. Evidence: E-rust-identified. Route: ida/radare2/re.
+
+### R53 Golang
+Trigger: runtime.*, go.string.*, newobject. Action: GoReSym-class symbol/type restore; distrust C-like decompile. Evidence: E-golang-identified.
+
+### R56 .NET Native AOT
+Trigger: native entry; no classic _CorExeMain/IL path. Action: do not force dnSpy IL workflow; native+AOT tools; managed IL stays dotnet-reverse. Evidence: E-dotnet-aot.
+
+### R57 Custom string crypto
+Trigger: high-entropy rdata without standard decoders. Action: entropy -> crypto constants -> dynamic decrypt dump. Evidence: E-string-custom-crypto.
+
+### R58 VMP / virtualizer (tiered)
+Trigger: VMP sections, vm_entry, extreme entropy. Action: Tier A qualitative+dynamic + E-vmp-protected; Tier B lab tracer under feasibility gate. MUST NOT claim full static undevirt without Evidence. Evidence: E-vmp-protected.
+
+### R62 Proxy DLL
+Trigger: exports overlap system DLL; loads real DLL; odd/missing forwarders. Action: diff exports; Path dropper->proxy->payload (R50). Evidence: E-proxy-dll.
+
+### R78 LLM hallucination
+Trigger: API/CFG claims without offset/tool output. Action: R41 grounded bar; else ungrounded. Evidence: E-llm-hallucination.
+
+### R80 Context pollution
+Trigger: contradicts confirmed Evidence/timeline; reused rejected hypothesis. Action: re-read timeline+Evidence (R2); drop polluted summary. Evidence: E-context-pollution.
+
+## 2. P1 short rows
+
+| ID | Action | Evidence |
+|----|--------|----------|
+| R54 C++ RTTI/EH | mark vtables, parse RTTI, xref virtuals | E-cpp-rtti |
+| R55 ObjC/Swift | class-dump, objc libs (Darwin) | E-objc-msg |
+| R59 OLLVM tier | P0/P1/P2; P2->dynamic; pointer A-T H | E-ollvm-level |
+| R60 combo | unflatten then predicates | E-obfuscation-combo |
+| R61 integrity | detect self-hash API; lab only | E-integrity-check |
+| R63 hollowing | SUSPENDED+unmap+WPM+resume detect | E-process-hollowing |
+| R64 APC | QueueUserAPC chain | E-apc-inject |
+| R65 AtomBombing | GlobalAddAtom chain | E-atom-bombing |
+| R66 doppelganging | TxF transaction chain | E-process-doppelganging |
+| R67 SEH+VEH | both + faults | E-exception-chain |
+| R68 BYOVD | signed sys + vuln hash DB + IOCTL detect | E-byovd-advanced |
+| R69 EDR cb | notify routines | E-edr-callback |
+| R70 PG/DSE | detect tamper intent only | E-kernel-protect-tamper |
+| R71 UEFI | efi/ESP | E-uefi-bootkit |
+| R72 cloud/IMDS | AWS_* / 169.254.169.254 | E-cloud-cred-theft |
+| R73 OLE | oleid/olevba/XLM/DDE | E-ole-analysis |
+| R74 PDF | /JS /OpenAction /Launch | E-pdf-malicious |
+| R75 WASM | wasm2wat imports | E-wasm-reverse |
+| R76 C2 proto | magic+handlers lab | E-custom-protocol |
+| R77 ELF | LD_PRELOAD/ptrace/proc | E-elf-linux |
+| R79 MCP boot | pin path only #76 | E-mcp-bootstrap |
+| R81 anchors | P2 idea -> R41/case-review | E-anchor-verify |
+
+## 3. P2 index
+
+OLLVM detail A-T H; IAT/TLS workflow; BYOVD/VBA U-AV; pin #76; decision ADF R1-R51.
+
+## 4. Safety
+
+Authorized lab only. R61/R70/injection = detect+Evidence, no bypass tutorial. Failures still Evidence.
+
+## 5. Checklist add-on
+
+6 language R52-R56; 7 packer tier R58-R60; 8 injection/proxy R62-R67; 9 grounded R78/R80+R41.

--- a/skills/ops/analysis-decision-framework.md
+++ b/skills/ops/analysis-decision-framework.md
@@ -149,4 +149,4 @@ Effort band + A-T pointers -> `E-anti-adversarial` (**no** A-T table copy).
 
 ## 5. Blindspot appendix (Issue #77 batch 2)
 
-Language runtimes, heavy obfuscation, injection/detect chains, formats, and agent-meta blindspots: see [nalysis-blindspot-cookbook.md](analysis-blindspot-cookbook.md) (**R52-R81**). Decision rules R1-R51 in this file remain superior.
+Language runtimes, heavy obfuscation, injection/detect chains, formats, and agent-meta blindspots: see [analysis-blindspot-cookbook.md](analysis-blindspot-cookbook.md) (**R52-R81**). Decision rules R1-R51 in this file remain superior.

--- a/skills/ops/analysis-decision-framework.md
+++ b/skills/ops/analysis-decision-framework.md
@@ -144,3 +144,9 @@ Effort band + A-T pointers -> `E-anti-adversarial` (**no** A-T table copy).
 3. R1 low confidence -> dynamic
 4. R43 deadlock -> replan under feasibility gate
 5. R8/R23 no default malice/IOC
+
+---
+
+## 5. Blindspot appendix (Issue #77 batch 2)
+
+Language runtimes, heavy obfuscation, injection/detect chains, formats, and agent-meta blindspots: see [nalysis-blindspot-cookbook.md](analysis-blindspot-cookbook.md) (**R52-R81**). Decision rules R1-R51 in this file remain superior.

--- a/skills/reverse-engineering/references/re-agent-workflow.md
+++ b/skills/reverse-engineering/references/re-agent-workflow.md
@@ -197,6 +197,9 @@
 
 Before closing Synthesis, apply [nalysis-decision-framework.md](../../ops/analysis-decision-framework.md) **P0 checklist**: R41 grounded claims, R4* validated sufficiency, R1 confidence->dynamic, R2 hypothesis exit, R43 deadlock replan (under feasibility gate), R8/R23 no default malice/IOC. Multi-module -> R50; anti-analysis effort -> R51 + A-T cookbook.
 
+Blindspots (Rust/Go/VMP/injection/OLE/PDF/agent-meta): [nalysis-blindspot-cookbook.md](../../ops/analysis-blindspot-cookbook.md) R52-R81 — detection-oriented; not a parallel master flow.
+
+
 
 ```text
 □ Finding：算法/校验逻辑/可利用点 / 行为结论

--- a/skills/reverse-engineering/references/re-agent-workflow.md
+++ b/skills/reverse-engineering/references/re-agent-workflow.md
@@ -195,9 +195,9 @@
 
 ### Decision quality overlay (Issue #77)
 
-Before closing Synthesis, apply [nalysis-decision-framework.md](../../ops/analysis-decision-framework.md) **P0 checklist**: R41 grounded claims, R4* validated sufficiency, R1 confidence->dynamic, R2 hypothesis exit, R43 deadlock replan (under feasibility gate), R8/R23 no default malice/IOC. Multi-module -> R50; anti-analysis effort -> R51 + A-T cookbook.
+Before closing Synthesis, apply [analysis-decision-framework.md](../../ops/analysis-decision-framework.md) **P0 checklist**: R41 grounded claims, R4* validated sufficiency, R1 confidence->dynamic, R2 hypothesis exit, R43 deadlock replan (under feasibility gate), R8/R23 no default malice/IOC. Multi-module -> R50; anti-analysis effort -> R51 + A-T cookbook.
 
-Blindspots (Rust/Go/VMP/injection/OLE/PDF/agent-meta): [nalysis-blindspot-cookbook.md](../../ops/analysis-blindspot-cookbook.md) R52-R81 — detection-oriented; not a parallel master flow.
+Blindspots (Rust/Go/VMP/injection/OLE/PDF/agent-meta): [analysis-blindspot-cookbook.md](../../ops/analysis-blindspot-cookbook.md) R52-R81 — detection-oriented; not a parallel master flow.
 
 
 

--- a/skills/scripts/verify-routing-coherence.ps1
+++ b/skills/scripts/verify-routing-coherence.ps1
@@ -442,6 +442,58 @@ $idCheck += "fastapi-in-ops-deps=false"
 $idCheck -join [Environment]::NewLine | Set-Content (Join-Path $ScratchDir 'identity-check.txt') -Encoding UTF8
 Ok 'identity-check written'
 
+# Issue #77 — analysis decision framework anchors (MUST run before fail gate)
+$adf = Join-Path $PackageRoot "skills\ops\analysis-decision-framework.md"
+if (Test-Path -LiteralPath $adf) { Ok "analysis-decision-framework.md present (issue #77)" } else { Bad "analysis-decision-framework.md missing (issue #77)" }
+if (Test-Path -LiteralPath $adf) {
+    $adfText = Get-Content -LiteralPath $adf -Raw -Encoding UTF8
+    foreach ($pair in @(
+        @("R4*", "ADF R4* validated sufficiency"),
+        @("E-insufficient-evidence", "ADF E-insufficient-evidence"),
+        @("E-hypothesis-confirmed", "ADF hypothesis evidence"),
+        @("ungrounded", "ADF ungrounded flag"),
+        @("Not** a second master", "ADF not second master workflow"),
+        @("analysis-blindspot-cookbook", "ADF links blindspot cookbook")
+    )) {
+        if ($adfText -like ("*" + $pair[0] + "*")) { Ok $pair[1] } else { Bad ("missing: " + $pair[1]) }
+    }
+}
+$efp77 = Join-Path $PackageRoot "skills\ops\evidence-finding-path.md"
+if (Test-Path -LiteralPath $efp77) {
+    $efpText = Get-Content -LiteralPath $efp77 -Raw -Encoding UTF8
+    if ($efpText -like "*analysis-decision-framework*") { Ok "evidence-finding-path hooks ADF" } else { Bad "evidence-finding-path missing ADF hook" }
+    if ($efpText -like "*E-insufficient-evidence*") { Ok "evidence-finding-path R4* id" } else { Bad "evidence-finding-path missing E-insufficient-evidence" }
+} else { Bad "evidence-finding-path.md missing" }
+$wf77 = Join-Path $PackageRoot "skills\reverse-engineering\references\re-agent-workflow.md"
+if (Test-Path -LiteralPath $wf77) {
+    $wfText = Get-Content -LiteralPath $wf77 -Raw -Encoding UTF8
+    if ($wfText -like "*analysis-decision-framework*") { Ok "re-agent-workflow hooks ADF" } else { Bad "re-agent-workflow missing ADF hook" }
+    if ($wfText -like "*analysis-blindspot-cookbook*") { Ok "re-agent-workflow hooks blindspot cookbook" } else { Bad "re-agent-workflow missing blindspot cookbook hook" }
+} else { Bad "re-agent-workflow.md missing" }
+$rules77 = Join-Path $PackageRoot "RULES.md"
+if (Test-Path -LiteralPath $rules77) {
+    $rulesText = Get-Content -LiteralPath $rules77 -Raw -Encoding UTF8
+    if ($rulesText -like "*analysis-decision-framework*") { Ok "RULES.md hooks ADF" } else { Bad "RULES.md missing ADF hook" }
+} else { Bad "RULES.md missing" }
+
+# Issue #77 batch 2 — blindspot cookbook anchors
+$bsc = Join-Path $PackageRoot "skills\ops\analysis-blindspot-cookbook.md"
+if (Test-Path -LiteralPath $bsc) { Ok "analysis-blindspot-cookbook.md present (issue77 R52-R81)" } else { Bad "analysis-blindspot-cookbook.md missing (issue77 R52-R81)" }
+if (Test-Path -LiteralPath $bsc) {
+    $bscText = Get-Content -LiteralPath $bsc -Raw -Encoding UTF8
+    foreach ($pair in @(
+        @("R52", "BSC R52 Rust"),
+        @("E-rust-identified", "BSC E-rust-identified"),
+        @("E-vmp-protected", "BSC E-vmp-protected"),
+        @("E-llm-hallucination", "BSC E-llm-hallucination"),
+        @("E-kernel-protect-tamper", "BSC kernel detect-only id"),
+        @("Not** a third master", "BSC not third master workflow"),
+        @("no bypass tutorial", "BSC no bypass tutorial")
+    )) {
+        if ($bscText -like ("*" + $pair[0] + "*")) { Ok $pair[1] } else { Bad ("missing: " + $pair[1]) }
+    }
+}
+
 Write-Host "Scratch=$ScratchDir"
 if ($fail.Count -gt 0) {
     Write-Host ("FAILED {0}" -f $fail.Count) -ForegroundColor Red
@@ -449,37 +501,6 @@ if ($fail.Count -gt 0) {
     $fail | Set-Content (Join-Path $ScratchDir 'failures.txt') -Encoding UTF8
     exit 1
 }
-Write-Host '
-# Issue #77 — analysis decision framework anchors
-$adf = Join-Path $PackageRoot "skills\ops\analysis-decision-framework.md"
-Assert-FileExists $adf "analysis-decision-framework.md (issue #77)"
-Assert-FileContains $adf "R4*" "ADF R4* validated sufficiency"
-Assert-FileContains $adf "E-insufficient-evidence" "ADF E-insufficient-evidence"
-Assert-FileContains $adf "E-hypothesis-confirmed" "ADF hypothesis evidence"
-Assert-FileContains $adf "ungrounded" "ADF ungrounded flag"
-Assert-FileContains $adf "Not** a second master" "ADF not second master workflow"
-$efp77 = Join-Path $PackageRoot "skills\ops\evidence-finding-path.md"
-Assert-FileContains $efp77 "analysis-decision-framework" "evidence-finding-path hooks ADF"
-Assert-FileContains $efp77 "E-insufficient-evidence" "evidence-finding-path R4* id"
-$wf77 = Join-Path $PackageRoot "skills\reverse-engineering\references\re-agent-workflow.md"
-Assert-FileContains $wf77 "analysis-decision-framework" "re-agent-workflow hooks ADF"
-$rules77 = Join-Path $PackageRoot "RULES.md"
-Assert-FileContains $rules77 "analysis-decision-framework" "RULES.md hooks ADF"
-
-
-# Issue 77 batch 2 blindspot cookbook anchors
-$bsc = Join-Path $PackageRoot "skills\ops\analysis-blindspot-cookbook.md"
-Assert-FileExists $bsc "analysis-blindspot-cookbook.md (issue77 R52-R81)"
-Assert-FileContains $bsc "R52" "BSC R52 Rust"
-Assert-FileContains $bsc "E-rust-identified" "BSC E-rust-identified"
-Assert-FileContains $bsc "E-vmp-protected" "BSC E-vmp-protected"
-Assert-FileContains $bsc "E-llm-hallucination" "BSC E-llm-hallucination"
-Assert-FileContains $bsc "E-kernel-protect-tamper" "BSC kernel detect-only id"
-Assert-FileContains $bsc "Not** a third master" "BSC not third master workflow"
-Assert-FileContains $bsc "no bypass tutorial" "BSC no bypass tutorial"
-$adf2 = Join-Path $PackageRoot "skills\ops\analysis-decision-framework.md"
-Assert-FileContains $adf2 "analysis-blindspot-cookbook" "ADF links blindspot cookbook"
-
-ALL ROUTING COHERENCE CHECKS PASSED' -ForegroundColor Green
+Write-Host 'ALL ROUTING COHERENCE CHECKS PASSED' -ForegroundColor Green
 'ALL ROUTING COHERENCE CHECKS PASSED' | Set-Content (Join-Path $ScratchDir 'verify.txt') -Encoding UTF8
 exit 0

--- a/skills/scripts/verify-routing-coherence.ps1
+++ b/skills/scripts/verify-routing-coherence.ps1
@@ -466,6 +466,20 @@ Assert-FileContains $wf77 "analysis-decision-framework" "re-agent-workflow hooks
 $rules77 = Join-Path $PackageRoot "RULES.md"
 Assert-FileContains $rules77 "analysis-decision-framework" "RULES.md hooks ADF"
 
+
+# Issue 77 batch 2 blindspot cookbook anchors
+$bsc = Join-Path $PackageRoot "skills\ops\analysis-blindspot-cookbook.md"
+Assert-FileExists $bsc "analysis-blindspot-cookbook.md (issue77 R52-R81)"
+Assert-FileContains $bsc "R52" "BSC R52 Rust"
+Assert-FileContains $bsc "E-rust-identified" "BSC E-rust-identified"
+Assert-FileContains $bsc "E-vmp-protected" "BSC E-vmp-protected"
+Assert-FileContains $bsc "E-llm-hallucination" "BSC E-llm-hallucination"
+Assert-FileContains $bsc "E-kernel-protect-tamper" "BSC kernel detect-only id"
+Assert-FileContains $bsc "Not** a third master" "BSC not third master workflow"
+Assert-FileContains $bsc "no bypass tutorial" "BSC no bypass tutorial"
+$adf2 = Join-Path $PackageRoot "skills\ops\analysis-decision-framework.md"
+Assert-FileContains $adf2 "analysis-blindspot-cookbook" "ADF links blindspot cookbook"
+
 ALL ROUTING COHERENCE CHECKS PASSED' -ForegroundColor Green
 'ALL ROUTING COHERENCE CHECKS PASSED' | Set-Content (Join-Path $ScratchDir 'verify.txt') -Encoding UTF8
 exit 0


### PR DESCRIPTION
## Summary
Issue #77 batch 2 (reporter R52–R81) — **方案 A2**.

- New `skills/ops/analysis-blindspot-cookbook.md` (P0 full + P1 short + P2 index)
- ADF §5 appendix link; `re-agent-workflow` blindspot pointer
- verify anchors for key Evidence IDs
- **Detection/forensics** for integrity/BYOVD/kernel/injection rows — no weaponized bypass tutorials
- Not a third master workflow; R1–R51 decision layer remains superior
- Skill-level thin hooks (malware/dotnet/edr SKILL.md) skipped this PR due to path guard; cookbook + ADF/workflow sufficient

## Test plan
- [x] Local smoke + verify ×3 on pwsh and Windows PowerShell 5.1 — ALL PASS
- [ ] CI green
- [ ] Maintainer confirm before merge main