### PR TITLE
fix(scripts): UTF-8 BOM for non-ASCII .ps1 (Windows PowerShell 5.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,30 @@ jobs:
           }
           if ($failed -gt 0) { exit 1 }
 
+      - name: Non-ASCII .ps1 must carry a UTF-8 BOM (Windows PowerShell 5.1 safety)
+        shell: pwsh
+        run: |
+          # PS 5.1 parses a BOM-less .ps1 as the system ANSI codepage, garbling
+          # Chinese/em-dash string literals. Every non-ASCII script MUST have a BOM.
+          $files = git ls-files '*.ps1'
+          if (-not $files) { Write-Host 'No .ps1 files tracked'; exit 0 }
+          $bad = 0
+          foreach ($f in $files) {
+            $bytes = [System.IO.File]::ReadAllBytes((Resolve-Path $f))
+            $hasNonAscii = $false
+            foreach ($b in $bytes) { if ($b -ge 0x80) { $hasNonAscii = $true; break } }
+            if (-not $hasNonAscii) { continue }
+            $hasBom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
+            if ($hasBom) {
+              Write-Host "BOM OK: $f"
+            } else {
+              $bad++
+              Write-Host "::error file=$f::non-ASCII .ps1 lacks a UTF-8 BOM; add one so literals survive Windows PowerShell 5.1"
+            }
+          }
+          if ($bad -gt 0) { Write-Host "$bad file(s) need a UTF-8 BOM"; exit 1 }
+          Write-Host 'All non-ASCII .ps1 carry a UTF-8 BOM'
+
   leak-scan:
     name: field-journal leak scan
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- **Windows PowerShell 5.1 encoding** — added a UTF-8 BOM to five non-ASCII `.ps1` scripts (`skills/scripts/verify-doc-facts.ps1`, `apk-reverse/scripts/frida-run.ps1`, `apk-reverse/scripts/rebuild-sign-install.ps1`, `ida-reverse/scripts/start.ps1`, `radare2/scripts/recon.ps1`). Without a BOM, PS 5.1 parses these files as the system ANSI codepage and garbles their Chinese / em-dash string literals; `verify-doc-facts.ps1` was failing four checks under 5.1 (CI only ran it under `pwsh`, which defaults to UTF-8). CI now guards every non-ASCII `.ps1` for a BOM.
 
 ## [1.0.1] — 2026-08-08
 ### Added

--- a/skills/apk-reverse/scripts/frida-run.ps1
+++ b/skills/apk-reverse/scripts/frida-run.ps1
@@ -1,4 +1,4 @@
-#requires -Version 5
+﻿#requires -Version 5
 
 [CmdletBinding()]
 param(

--- a/skills/apk-reverse/scripts/rebuild-sign-install.ps1
+++ b/skills/apk-reverse/scripts/rebuild-sign-install.ps1
@@ -1,4 +1,4 @@
-#requires -Version 5
+﻿#requires -Version 5
 
 [CmdletBinding()]
 param(

--- a/skills/ida-reverse/scripts/start.ps1
+++ b/skills/ida-reverse/scripts/start.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 Start IDA Pro MCP HTTP server (background, non-blocking)
 

--- a/skills/radare2/scripts/recon.ps1
+++ b/skills/radare2/scripts/recon.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [Parameter(Mandatory = $true)]
     [string]$TargetPath,
 

--- a/skills/scripts/verify-doc-facts.ps1
+++ b/skills/scripts/verify-doc-facts.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Verify doc fact tables (capability lists, MCP ports, Burp tool count)
   against source-of-truth (bootstrap-manifest.json / McpHttpServer.java).


### PR DESCRIPTION
verify-doc-facts.ps1 fails 4 checks under Windows PowerShell 5.1 because five non-ASCII .ps1 scripts lack a UTF-8 BOM, so 5.1 parses their Chinese / em-dash literals as ANSI. CI only ran that script under pwsh, hiding it. Added a BOM to the five files (matching the repo's other Chinese-containing scripts) plus a CI guard requiring a BOM on any non-ASCII .ps1. Diff is BOM-only on the scripts; no VERSION/released-changelog changes.