### PR TITLE
fix(test): make bootstrap manifest regression hermetic

### DIFF
--- a/skills/scripts/test-bootstrap-manifest.sh
+++ b/skills/scripts/test-bootstrap-manifest.sh
@@ -72,6 +72,74 @@ exec "$REAL_PYTHON" "\$@"
 STUB
 chmod +x "$STUB_BIN/python3"
 
+# Keep the Kali subflow hermetic on generic Linux/macOS hosts. The Kali
+# bootstrap reads its manifest with jq, but this regression test must not
+# depend on the host having jq installed just to exercise that code path.
+JQ_STUB_PY="$SCRATCH/jq-stub.py"
+cat > "$JQ_STUB_PY" <<'PY'
+import json
+import re
+import sys
+
+args = sys.argv[1:]
+raw = False
+exit_status = False
+variables = {}
+positionals = []
+i = 0
+while i < len(args):
+    arg = args[i]
+    if arg.startswith('-') and set(arg[1:]) <= {'e', 'r'}:
+        raw = raw or 'r' in arg
+        exit_status = exit_status or 'e' in arg
+        i += 1
+        continue
+    if arg == '--arg':
+        variables[args[i + 1]] = args[i + 2]
+        i += 3
+        continue
+    positionals.append(arg)
+    i += 1
+
+if not positionals:
+    raise SystemExit(2)
+
+expression = positionals[0]
+input_path = positionals[1] if len(positionals) > 1 else None
+if input_path:
+    with open(input_path, encoding='utf-8') as handle:
+        data = json.load(handle)
+else:
+    data = json.load(sys.stdin)
+
+if expression == '.bootstrapDependencies[$name][$field] // empty':
+    result = data.get('bootstrapDependencies', {}).get(variables['name'], {}).get(variables['field'])
+elif expression == '.capabilities[] | select(.name == $name) | .[$field] // empty':
+    capability = next((item for item in data.get('capabilities', []) if item.get('name') == variables['name']), None)
+    result = None if capability is None else capability.get(variables['field'])
+elif expression in ('.name', '.status'):
+    result = data.get(expression[1:])
+else:
+    match = re.fullmatch(r'\.mcpServers\."([^"]+)"\s*=\s*(.+)', expression)
+    if not match:
+        raise SystemExit(2)
+    data.setdefault('mcpServers', {})[match.group(1)] = json.loads(match.group(2))
+    result = data
+
+if exit_status and (result is None or result is False or result == ''):
+    raise SystemExit(1)
+if raw and not isinstance(result, (dict, list)):
+    print('' if result is None else result)
+else:
+    print(json.dumps(result, ensure_ascii=False))
+PY
+
+cat > "$STUB_BIN/jq" <<STUB
+#!/usr/bin/env bash
+exec "$REAL_PYTHON" "$JQ_STUB_PY" "\$@"
+STUB
+chmod +x "$STUB_BIN/jq"
+
 json_value() {
   "$REAL_PYTHON" - "$MANIFEST" "$1" "$2" <<'PY'
 import json, pathlib, sys


### PR DESCRIPTION
## Summary

Make `skills/scripts/test-bootstrap-manifest.sh` hermetic when it exercises the Kali bootstrap path on generic Linux/macOS hosts.

The regression test already stubs Git, npm, pnpm, nc, apt, Python, and other external commands, but the Kali subflow also requires `jq` to read `bootstrap-manifest.json`. On a clean Ubuntu/WSL host without jq, that subflow returned before the pnpm assertion and produced a false bootstrap regression.

This change adds a test-local jq fixture backed by the already-discovered Python runtime. It implements only the jq operations the Kali bootstrap path uses in this test: manifest field/dependency reads, MCP config assignment, and result name/status reads. Production bootstrap scripts and manifests are unchanged.

## Root cause

`test-bootstrap-manifest.sh` had an undeclared host dependency on `jq` in its Kali subflow. The same failure reproduces on pristine upstream `main` (`a9ed8d04`) when run on Ubuntu without jq.

## Validation

All required checks from `AGENTS.md` pass after the fix:

- Windows `test-routing.ps1`: 168/168 PASS
- Windows `verify-routing-coherence.ps1`: PASS
- Windows `smoke.ps1`: PASS (`PARSE 18/18`, routes 9/9)
- WSL/Linux `test-routing.sh`: 168/168 + default-root PASS
- WSL/Linux `test-bootstrap-manifest.sh`: PASS (`bootstrap manifest source regression passed`)
- `git diff --check`: PASS

## Scope

- 1 test file changed
- No production bootstrap behavior changed
- No routing/auth/client-default behavior changed
- Independent from PR #95
