### PR TITLE
test(ci): run three existing-but-unwired test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,17 @@ jobs:
         shell: powershell
         run: ./skills/scripts/test-bootstrap-supply-chain.ps1
 
+      # Windows-only: these tests spawn powershell.exe and assert PS 5.1 behaviour.
+      - name: P0 friction regression (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: ./skills/scripts/test-p0-friction.ps1
+
+      - name: Workflow title-injection safety (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: ./skills/scripts/test-workflow-title-safety.ps1
+
       - name: Smoke (verify + parse + quick route)
         shell: pwsh
         run: ./skills/scripts/smoke.ps1
@@ -182,6 +193,10 @@ jobs:
       - name: Review examples/ctf-demo under strict contract
         shell: bash
         run: python3 skills/case-review/scripts/review_case.py examples/ctf-demo --verify-hashes --strict
+
+      - name: review_case.py unit tests
+        shell: bash
+        run: python3 skills/case-review/tests/test_review_case.py
 
   version-check:
     name: version consistency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- **CI now runs three existing-but-unwired test suites** — `test-p0-friction.ps1` (P0 auth-gate / path-traversal / case-contract regression) and `test-workflow-title-safety.ps1` (workflow title-injection safety) run on the Windows leg of the `routing-tests` job under Windows PowerShell 5.1 (both spawn `powershell.exe` and assert 5.1 behaviour); `case-review/tests/test_review_case.py` (8 `unittest` cases) runs in the Linux `case-contract` job. These tests shipped in the repo but nothing executed them.
 
 ## [1.0.1] — 2026-08-08
 ### Added


### PR DESCRIPTION
Wires test-p0-friction.ps1, test-workflow-title-safety.ps1, and case-review/tests/test_review_case.py into CI. The two PowerShell suites run on the Windows leg of routing-tests under Windows PowerShell 5.1 (Windows-gated, they spawn powershell.exe); test_review_case.py (plain unittest, no new dep) runs in the Linux case-contract job. All three pass locally.