### PR TITLE
fix(ci): add UTF-8 BOM to non-ASCII .ps1 scripts

### DIFF
--- a/skills/scripts/smoke.ps1
+++ b/skills/scripts/smoke.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 # reverse-skill smoke entrypoint: verify + script parse + master-route sample matrix.
 # Usage:
 #   powershell -NoProfile -ExecutionPolicy Bypass -File skills/scripts/smoke.ps1

--- a/skills/scripts/test-bootstrap-codex-encoding.ps1
+++ b/skills/scripts/test-bootstrap-codex-encoding.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 param(
     [string]$ScratchDir = ''
 )


### PR DESCRIPTION
smoke.ps1 and test-bootstrap-codex-encoding.ps1 contain Chinese string literals but lack a UTF-8 BOM. Windows PowerShell 5.1 parses BOM-less files as the system ANSI codepage, garbling those literals. The CI BOM gate already catches this; adding the three-byte prefix fixes both files.