### PR TITLE
test(ci): wire remaining unwired suites (#97 rebase)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
         shell: pwsh
         run: ./skills/scripts/test-workflow-title-safety.ps1
 
+      - name: P0 friction regression (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: ./skills/scripts/test-p0-friction.ps1
+
       - name: Client-neutral bootstrap/discovery (Windows PowerShell 5.1)
         if: runner.os == 'Windows'
         shell: powershell
@@ -312,6 +317,10 @@ jobs:
       - name: Review examples/ctf-demo under strict contract
         shell: bash
         run: python3 skills/case-review/scripts/review_case.py examples/ctf-demo --verify-hashes --strict
+
+      - name: review_case.py unit tests
+        shell: bash
+        run: python3 skills/case-review/tests/test_review_case.py
 
   version-check:
     name: version consistency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- **CI runs remaining unwired suites** — 	est-p0-friction.ps1 on the Windows leg of outing-tests (Windows PowerShell 5.1); case-review/tests/test_review_case.py in the Linux case-contract job. 	est-workflow-title-safety.ps1 was already wired.
+
 ### Fixed
 - **Windows PowerShell 5.1 encoding** — added a UTF-8 BOM to five non-ASCII `.ps1` scripts (`skills/scripts/verify-doc-facts.ps1`, `apk-reverse/scripts/frida-run.ps1`, `apk-reverse/scripts/rebuild-sign-install.ps1`, `ida-reverse/scripts/start.ps1`, `radare2/scripts/recon.ps1`). Without a BOM, PS 5.1 parses these files as the system ANSI codepage and garbles their Chinese / em-dash string literals; `verify-doc-facts.ps1` was failing four checks under 5.1 (CI only ran it under `pwsh`, which defaults to UTF-8). CI now guards every non-ASCII `.ps1` for a BOM.
 


### PR DESCRIPTION
## Summary

Rebase of useful #97 onto current main after later CI edits made the original PR **CONFLICTING**.

## What lands

- Windows `routing-tests`: `test-p0-friction.ps1` under Windows PowerShell 5.1
- Linux `case-contract`: `python3 skills/case-review/tests/test_review_case.py` (8 unittests)
- **Not** re-adding `test-workflow-title-safety.ps1` — already wired on main as "Journal PR title safety"

## Local

- `test-p0-friction.ps1` under pwsh: ALL PASS
- `test-p0-friction.ps1` under PS 5.1 on this machine: FAIL (Get-FileHash / encoding garbled via nested powershell.exe — environment; CI Windows runner is the intended host)
- `test_review_case.py`: 8 tests OK
- title-safety: already PASS

## Credit

Original: dex0shubham in #97.