### PR TITLE
feat(workflow): add consolidate-evidence scripts and support supersed…

### DIFF
--- a/skills/case-review/scripts/review_case.py
+++ b/skills/case-review/scripts/review_case.py
@@ -19,7 +19,7 @@ FINDING_HEADING = re.compile(r"^###\s+(F-[A-Za-z0-9][A-Za-z0-9_-]*)\b", re.MULTI
 PATH_HEADING = re.compile(r"^###\s+(P-[A-Za-z0-9][A-Za-z0-9_-]*)\b", re.MULTILINE)
 
 SEVERITIES = {"critical", "high", "medium", "low", "info", "n/a", "n/a_re"}
-EVIDENCE_STATUSES = {"observed", "candidate", "validated", "false_positive", "accepted_risk"}
+EVIDENCE_STATUSES = {"observed", "candidate", "validated", "false_positive", "accepted_risk", "superseded"}
 WORKITEM_STATUSES = {"pending", "in_progress", "blocked", "done", "completed", "cancelled"}
 PATH_TYPES = {"attack", "callflow", "solve"}
 NETWORK_MODES = {"offline", "lab_only", "authorized_target_only", "unrestricted_lab"}
@@ -219,7 +219,7 @@ def parse_reports(root, issues):
             for field in required:
                 if not field_value(body, field):
                     issue(issues, "error", "finding.field_missing", finding_id + " is missing " + field, relative_path(root, report_path))
-            if status not in {"candidate", "validated", "false_positive", "accepted_risk"}:
+            if status not in {"candidate", "validated", "false_positive", "accepted_risk", "superseded"}:
                 issue(issues, "error", "finding.status", finding_id + " has unsupported status", relative_path(root, report_path))
             if status == "validated" and confidence == "low":
                 issue(issues, "error", "finding.confidence", finding_id + " is validated with low confidence", relative_path(root, report_path))
@@ -306,6 +306,8 @@ def parse_evidence(root, workitems, issues, verify_hashes):
 
         severity = field_value(text, "severity").lower()
         status = field_value(text, "status").lower()
+        if status.startswith("superseded by"):
+            status = "superseded"
         repro_command = field_value(text, "repro_command")
         notes = field_value(text, "notes").lower()
         linked_workitems = ids_in(field_value(text, "linked_workitem"), WORKITEM_ID)

--- a/skills/scripts/consolidate-evidence.ps1
+++ b/skills/scripts/consolidate-evidence.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $CaseRoot,
+    [Parameter(Mandatory = $true)][string] $EvidenceIds,
+    [Parameter(Mandatory = $true)][string] $FindingId,
+    [Parameter(Mandatory = $true)][string] $Title,
+    [Parameter(Mandatory = $true)][string] $Description,
+    [string] $Severity = 'medium',
+    [string] $Status = 'validated'
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path -Path $CaseRoot)) { Write-Error "CaseRoot not found: $CaseRoot" }
+
+$evidenceDir = Join-Path $CaseRoot "evidence"
+$reportDir = Join-Path $CaseRoot "report"
+
+if (-not (Test-Path -Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir -Force | Out-Null }
+
+$idList = $EvidenceIds -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+if ($idList.Count -eq 0) { Write-Error "No Evidence IDs provided." }
+
+foreach ($id in $idList) {
+    $evidenceFile = Join-Path $evidenceDir "$id.md"
+    if (-not (Test-Path -Path $evidenceFile)) { Write-Error "Evidence file not found: $evidenceFile" }
+}
+
+foreach ($id in $idList) {
+    $evidenceFile = Join-Path $evidenceDir "$id.md"
+    $content = Get-Content -Path $evidenceFile -Raw
+    if ($content -match "(?m)^-\s*status:\s*.*$") {
+        $content = $content -replace "(?m)^-\s*status:\s*.*$", "- status: superseded by $FindingId"
+    } else {
+        $content = $content -replace "(?m)^---$", "---`n- status: superseded by $FindingId"
+    }
+    Set-Content -Path $evidenceFile -Value $content -NoNewline
+}
+
+$reportFile = Join-Path $reportDir "report.md"
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+$findingBlock = @"
+### $FindingId
+- title: $Title
+- severity: $Severity
+- status: $Status
+- evidence_refs: $($idList -join ', ')
+- consolidated_at: $timestamp
+
+$Description
+
+"@
+
+if (Test-Path -Path $reportFile) {
+    $reportContent = Get-Content -Path $reportFile -Raw
+    if ($reportContent -notmatch "(?m)^## Findings") { Add-Content -Path $reportFile -Value "`n## Findings`n" }
+    Add-Content -Path $reportFile -Value $findingBlock
+} else {
+    $initialReport = @"
+# Case Report
+
+## Findings
+
+$findingBlock
+"@
+    Set-Content -Path $reportFile -Value $initialReport
+}

--- a/skills/scripts/consolidate_evidence.py
+++ b/skills/scripts/consolidate_evidence.py
@@ -1,0 +1,68 @@
+import argparse
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+def main( ):
+    parser = argparse.ArgumentParser(description="Consolidate Evidence into Finding")
+    parser.add_argument("--case-root", required=True)
+    parser.add_argument("--evidence-ids", required=True, help="Comma-separated E-xxx")
+    parser.add_argument("--finding-id", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--description", required=True)
+    parser.add_argument("--severity", default="medium")
+    parser.add_argument("--status", default="validated")
+    args = parser.parse_args()
+
+    case_root = Path(args.case_root)
+    evidence_dir = case_root / "evidence"
+    report_dir = case_root / "report"
+    report_dir.mkdir(exist_ok=True)
+
+    ids = [i.strip() for i in args.evidence_ids.split(",") if i.strip()]
+    for eid in ids:
+        f = evidence_dir / f"{eid}.md"
+        if not f.exists():
+            print(f"Error: {f} not found")
+            return
+            
+    for eid in ids:
+        f = evidence_dir / f"{eid}.md"
+        content = f.read_text(encoding="utf-8-sig")
+        if re.search(r"(?m)^-\s*status:\s*.*$", content):
+            content = re.sub(r"(?m)^-\s*status:\s*.*$", f"- status: superseded by {args.finding_id}", content)
+        else:
+            content = re.sub(r"(?m)^---$", f"---\n- status: superseded by {args.finding_id}", content, count=1)
+        f.write_text(content, encoding="utf-8-sig")
+        print(f"Marked {eid} as superseded")
+
+    report_file = report_dir / "report.md"
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    
+    finding_block = f"""
+### {args.finding_id}
+- title: {args.title}
+- severity: {args.severity}
+- status: {args.status}
+- confidence: high
+- location: Multiple locations
+- evidence_ids: {', '.join(ids)}
+- consolidated_at: {ts}
+
+{args.description}
+"""
+    if report_file.exists():
+        content = report_file.read_text(encoding="utf-8-sig")
+        if "## Findings" not in content:
+            with report_file.open("a", encoding="utf-8-sig") as f:
+                f.write("\n## Findings\n")
+        with report_file.open("a", encoding="utf-8-sig") as f:
+            f.write(finding_block)
+    else:
+        report_file.write_text(f"# Case Report\n\n## Findings\n{finding_block}", encoding="utf-8-sig")
+    
+    print(f"Successfully consolidated {len(ids)} evidence items into {args.finding_id}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add Python and PowerShell helpers to consolidate related Evidence records into one Finding
- - mark source Evidence records as superseded by the resulting Finding
- - extend case review parsing to accept superseded Evidence status
## Validation

- `python3 -m py_compile skills/scripts/consolidate_evidence.py`
- - `git diff --check`
- - manually verified Evidence consolidation and report generation
Related: #62