### PR TITLE
fix(workflow): align consolidate-evidence Finding fields (#114)

### DIFF
--- a/skills/case-review/scripts/review_case.py
+++ b/skills/case-review/scripts/review_case.py
@@ -19,7 +19,7 @@ FINDING_HEADING = re.compile(r"^###\s+(F-[A-Za-z0-9][A-Za-z0-9_-]*)\b", re.MULTI
 PATH_HEADING = re.compile(r"^###\s+(P-[A-Za-z0-9][A-Za-z0-9_-]*)\b", re.MULTILINE)
 
 SEVERITIES = {"critical", "high", "medium", "low", "info", "n/a", "n/a_re"}
-EVIDENCE_STATUSES = {"observed", "candidate", "validated", "false_positive", "accepted_risk"}
+EVIDENCE_STATUSES = {"observed", "candidate", "validated", "false_positive", "accepted_risk", "superseded"}
 WORKITEM_STATUSES = {"pending", "in_progress", "blocked", "done", "completed", "cancelled"}
 PATH_TYPES = {"attack", "callflow", "solve"}
 NETWORK_MODES = {"offline", "lab_only", "authorized_target_only", "unrestricted_lab"}
@@ -219,7 +219,7 @@ def parse_reports(root, issues):
             for field in required:
                 if not field_value(body, field):
                     issue(issues, "error", "finding.field_missing", finding_id + " is missing " + field, relative_path(root, report_path))
-            if status not in {"candidate", "validated", "false_positive", "accepted_risk"}:
+            if status not in {"candidate", "validated", "false_positive", "accepted_risk", "superseded"}:
                 issue(issues, "error", "finding.status", finding_id + " has unsupported status", relative_path(root, report_path))
             if status == "validated" and confidence == "low":
                 issue(issues, "error", "finding.confidence", finding_id + " is validated with low confidence", relative_path(root, report_path))
@@ -306,6 +306,8 @@ def parse_evidence(root, workitems, issues, verify_hashes):
 
         severity = field_value(text, "severity").lower()
         status = field_value(text, "status").lower()
+        if status.startswith("superseded by"):
+            status = "superseded"
         repro_command = field_value(text, "repro_command")
         notes = field_value(text, "notes").lower()
         linked_workitems = ids_in(field_value(text, "linked_workitem"), WORKITEM_ID)

--- a/skills/scripts/consolidate-evidence.ps1
+++ b/skills/scripts/consolidate-evidence.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string] $CaseRoot,
+    [Parameter(Mandatory = $true)][string] $EvidenceIds,
+    [Parameter(Mandatory = $true)][string] $FindingId,
+    [Parameter(Mandatory = $true)][string] $Title,
+    [Parameter(Mandatory = $true)][string] $Description,
+    [string] $Severity = 'medium',
+    [string] $Status = 'validated'
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path -Path $CaseRoot)) { Write-Error "CaseRoot not found: $CaseRoot" }
+
+$evidenceDir = Join-Path $CaseRoot "evidence"
+$reportDir = Join-Path $CaseRoot "report"
+
+if (-not (Test-Path -Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir -Force | Out-Null }
+
+$idList = $EvidenceIds -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+if ($idList.Count -eq 0) { Write-Error "No Evidence IDs provided." }
+
+foreach ($id in $idList) {
+    $evidenceFile = Join-Path $evidenceDir "$id.md"
+    if (-not (Test-Path -Path $evidenceFile)) { Write-Error "Evidence file not found: $evidenceFile" }
+}
+
+foreach ($id in $idList) {
+    $evidenceFile = Join-Path $evidenceDir "$id.md"
+    $content = Get-Content -Path $evidenceFile -Raw
+    if ($content -match "(?m)^-\s*status:\s*.*$") {
+        $content = $content -replace "(?m)^-\s*status:\s*.*$", "- status: superseded by $FindingId"
+    } else {
+        $content = $content -replace "(?m)^---$", "---`n- status: superseded by $FindingId"
+    }
+    Set-Content -Path $evidenceFile -Value $content -NoNewline
+}
+
+$reportFile = Join-Path $reportDir "report.md"
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+$findingBlock = @"
+### $FindingId
+- title: $Title
+- severity: $Severity
+- status: $Status
+- evidence_refs: $($idList -join ', ')
+- consolidated_at: $timestamp
+
+$Description
+
+"@
+
+if (Test-Path -Path $reportFile) {
+    $reportContent = Get-Content -Path $reportFile -Raw
+    if ($reportContent -notmatch "(?m)^## Findings") { Add-Content -Path $reportFile -Value "`n## Findings`n" }
+    Add-Content -Path $reportFile -Value $findingBlock
+} else {
+    $initialReport = @"
+# Case Report
+
+## Findings
+
+$findingBlock
+"@
+    Set-Content -Path $reportFile -Value $initialReport
+}

--- a/skills/scripts/consolidate-evidence.ps1
+++ b/skills/scripts/consolidate-evidence.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string] $CaseRoot,
@@ -7,55 +7,61 @@ param(
     [Parameter(Mandatory = $true)][string] $Title,
     [Parameter(Mandatory = $true)][string] $Description,
     [string] $Severity = 'medium',
-    [string] $Status = 'validated'
+    [string] $Status = 'validated',
+    [string] $Confidence = 'medium',
+    [string] $Location = 'see evidence_ids'
 )
 
 $ErrorActionPreference = 'Stop'
-if (-not (Test-Path -Path $CaseRoot)) { Write-Error "CaseRoot not found: $CaseRoot" }
+if (-not (Test-Path -LiteralPath $CaseRoot)) { Write-Error "CaseRoot not found: $CaseRoot" }
 
 $evidenceDir = Join-Path $CaseRoot "evidence"
 $reportDir = Join-Path $CaseRoot "report"
+if (-not (Test-Path -LiteralPath $reportDir)) { New-Item -ItemType Directory -Path $reportDir -Force | Out-Null }
 
-if (-not (Test-Path -Path $reportDir)) { New-Item -ItemType Directory -Path $reportDir -Force | Out-Null }
-
-$idList = $EvidenceIds -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+$idList = @($EvidenceIds -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' })
 if ($idList.Count -eq 0) { Write-Error "No Evidence IDs provided." }
 
 foreach ($id in $idList) {
     $evidenceFile = Join-Path $evidenceDir "$id.md"
-    if (-not (Test-Path -Path $evidenceFile)) { Write-Error "Evidence file not found: $evidenceFile" }
+    if (-not (Test-Path -LiteralPath $evidenceFile)) { Write-Error "Evidence file not found: $evidenceFile" }
 }
 
 foreach ($id in $idList) {
     $evidenceFile = Join-Path $evidenceDir "$id.md"
-    $content = Get-Content -Path $evidenceFile -Raw
+    $content = Get-Content -LiteralPath $evidenceFile -Raw -Encoding UTF8
     if ($content -match "(?m)^-\s*status:\s*.*$") {
-        $content = $content -replace "(?m)^-\s*status:\s*.*$", "- status: superseded by $FindingId"
+        $content = [regex]::Replace($content, "(?m)^-\s*status:\s*.*$", "- status: superseded by $FindingId")
+    } elseif ($content -match "(?m)^---\s*$") {
+        $content = [regex]::Replace($content, "(?m)^---\s*$", "---`r`n- status: superseded by $FindingId", 1)
     } else {
-        $content = $content -replace "(?m)^---$", "---`n- status: superseded by $FindingId"
+        $content = $content.TrimEnd() + "`r`n- status: superseded by $FindingId`r`n"
     }
-    Set-Content -Path $evidenceFile -Value $content -NoNewline
+    Set-Content -LiteralPath $evidenceFile -Value $content -Encoding UTF8 -NoNewline
 }
 
-$reportFile = Join-Path $reportDir "report.md"
 $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-
+$joined = ($idList -join ', ')
 $findingBlock = @"
 ### $FindingId
 - title: $Title
 - severity: $Severity
 - status: $Status
-- evidence_refs: $($idList -join ', ')
+- confidence: $Confidence
+- location: $Location
+- evidence_ids: $joined
 - consolidated_at: $timestamp
 
 $Description
-
 "@
 
-if (Test-Path -Path $reportFile) {
-    $reportContent = Get-Content -Path $reportFile -Raw
-    if ($reportContent -notmatch "(?m)^## Findings") { Add-Content -Path $reportFile -Value "`n## Findings`n" }
-    Add-Content -Path $reportFile -Value $findingBlock
+$reportFile = Join-Path $reportDir "report.md"
+if (Test-Path -LiteralPath $reportFile) {
+    $reportContent = Get-Content -LiteralPath $reportFile -Raw -Encoding UTF8
+    if ($reportContent -notmatch "(?m)^## Findings") {
+        $reportContent = $reportContent.TrimEnd() + "`r`n`r`n## Findings`r`n"
+    }
+    Set-Content -LiteralPath $reportFile -Value ($reportContent.TrimEnd() + "`r`n`r`n" + $findingBlock + "`r`n") -Encoding UTF8 -NoNewline
 } else {
     $initialReport = @"
 # Case Report
@@ -64,5 +70,5 @@ if (Test-Path -Path $reportFile) {
 
 $findingBlock
 "@
-    Set-Content -Path $reportFile -Value $initialReport
+    Set-Content -LiteralPath $reportFile -Value $initialReport -Encoding UTF8
 }

--- a/skills/scripts/consolidate_evidence.py
+++ b/skills/scripts/consolidate_evidence.py
@@ -1,10 +1,33 @@
 import argparse
-import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-def main( ):
+
+def mark_superseded(content, finding_id):
+    if re.search(r"(?m)^-\s*status:\s*.*$", content):
+        return re.sub(r"(?m)^-\s*status:\s*.*$", f"- status: superseded by {finding_id}", content)
+    if re.search(r"(?m)^---\s*$", content):
+        return re.sub(r"(?m)^---\s*$", f"---\n- status: superseded by {finding_id}", content, count=1)
+    return content.rstrip() + f"\n- status: superseded by {finding_id}\n"
+
+
+def finding_block(finding_id, title, severity, status, confidence, location, ids, description, ts):
+    return (
+        f"### {finding_id}\n"
+        f"- title: {title}\n"
+        f"- severity: {severity}\n"
+        f"- status: {status}\n"
+        f"- confidence: {confidence}\n"
+        f"- location: {location}\n"
+        f"- evidence_ids: {', '.join(ids)}\n"
+        f"- consolidated_at: {ts}\n\n"
+        f"{description}\n"
+    )
+
+
+def main():
     parser = argparse.ArgumentParser(description="Consolidate Evidence into Finding")
     parser.add_argument("--case-root", required=True)
     parser.add_argument("--evidence-ids", required=True, help="Comma-separated E-xxx")
@@ -13,6 +36,8 @@ def main( ):
     parser.add_argument("--description", required=True)
     parser.add_argument("--severity", default="medium")
     parser.add_argument("--status", default="validated")
+    parser.add_argument("--confidence", default="medium")
+    parser.add_argument("--location", default="see evidence_ids")
     args = parser.parse_args()
 
     case_root = Path(args.case_root)
@@ -21,48 +46,37 @@ def main( ):
     report_dir.mkdir(exist_ok=True)
 
     ids = [i.strip() for i in args.evidence_ids.split(",") if i.strip()]
+    if not ids:
+        print("Error: no Evidence IDs provided", file=sys.stderr)
+        return 1
     for eid in ids:
         f = evidence_dir / f"{eid}.md"
         if not f.exists():
-            print(f"Error: {f} not found")
-            return
-            
+            print(f"Error: {f} not found", file=sys.stderr)
+            return 1
+
     for eid in ids:
         f = evidence_dir / f"{eid}.md"
         content = f.read_text(encoding="utf-8-sig")
-        if re.search(r"(?m)^-\s*status:\s*.*$", content):
-            content = re.sub(r"(?m)^-\s*status:\s*.*$", f"- status: superseded by {args.finding_id}", content)
-        else:
-            content = re.sub(r"(?m)^---$", f"---\n- status: superseded by {args.finding_id}", content, count=1)
-        f.write_text(content, encoding="utf-8-sig")
+        f.write_text(mark_superseded(content, args.finding_id), encoding="utf-8-sig")
         print(f"Marked {eid} as superseded")
 
     report_file = report_dir / "report.md"
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    
-    finding_block = f"""
-### {args.finding_id}
-- title: {args.title}
-- severity: {args.severity}
-- status: {args.status}
-- confidence: high
-- location: Multiple locations
-- evidence_ids: {', '.join(ids)}
-- consolidated_at: {ts}
-
-{args.description}
-"""
+    block = finding_block(
+        args.finding_id, args.title, args.severity, args.status,
+        args.confidence, args.location, ids, args.description, ts,
+    )
     if report_file.exists():
         content = report_file.read_text(encoding="utf-8-sig")
         if "## Findings" not in content:
-            with report_file.open("a", encoding="utf-8-sig") as f:
-                f.write("\n## Findings\n")
-        with report_file.open("a", encoding="utf-8-sig") as f:
-            f.write(finding_block)
+            content = content.rstrip() + "\n\n## Findings\n"
+        report_file.write_text(content.rstrip() + "\n\n" + block, encoding="utf-8-sig")
     else:
-        report_file.write_text(f"# Case Report\n\n## Findings\n{finding_block}", encoding="utf-8-sig")
-    
+        report_file.write_text("# Case Report\n\n## Findings\n\n" + block, encoding="utf-8-sig")
     print(f"Successfully consolidated {len(ids)} evidence items into {args.finding_id}")
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/skills/scripts/consolidate_evidence.py
+++ b/skills/scripts/consolidate_evidence.py
@@ -1,0 +1,68 @@
+import argparse
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+def main( ):
+    parser = argparse.ArgumentParser(description="Consolidate Evidence into Finding")
+    parser.add_argument("--case-root", required=True)
+    parser.add_argument("--evidence-ids", required=True, help="Comma-separated E-xxx")
+    parser.add_argument("--finding-id", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--description", required=True)
+    parser.add_argument("--severity", default="medium")
+    parser.add_argument("--status", default="validated")
+    args = parser.parse_args()
+
+    case_root = Path(args.case_root)
+    evidence_dir = case_root / "evidence"
+    report_dir = case_root / "report"
+    report_dir.mkdir(exist_ok=True)
+
+    ids = [i.strip() for i in args.evidence_ids.split(",") if i.strip()]
+    for eid in ids:
+        f = evidence_dir / f"{eid}.md"
+        if not f.exists():
+            print(f"Error: {f} not found")
+            return
+            
+    for eid in ids:
+        f = evidence_dir / f"{eid}.md"
+        content = f.read_text(encoding="utf-8-sig")
+        if re.search(r"(?m)^-\s*status:\s*.*$", content):
+            content = re.sub(r"(?m)^-\s*status:\s*.*$", f"- status: superseded by {args.finding_id}", content)
+        else:
+            content = re.sub(r"(?m)^---$", f"---\n- status: superseded by {args.finding_id}", content, count=1)
+        f.write_text(content, encoding="utf-8-sig")
+        print(f"Marked {eid} as superseded")
+
+    report_file = report_dir / "report.md"
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    
+    finding_block = f"""
+### {args.finding_id}
+- title: {args.title}
+- severity: {args.severity}
+- status: {args.status}
+- confidence: high
+- location: Multiple locations
+- evidence_ids: {', '.join(ids)}
+- consolidated_at: {ts}
+
+{args.description}
+"""
+    if report_file.exists():
+        content = report_file.read_text(encoding="utf-8-sig")
+        if "## Findings" not in content:
+            with report_file.open("a", encoding="utf-8-sig") as f:
+                f.write("\n## Findings\n")
+        with report_file.open("a", encoding="utf-8-sig") as f:
+            f.write(finding_block)
+    else:
+        report_file.write_text(f"# Case Report\n\n## Findings\n{finding_block}", encoding="utf-8-sig")
+    
+    print(f"Successfully consolidated {len(ids)} evidence items into {args.finding_id}")
+
+if __name__ == "__main__":
+    main()

--- a/skills/scripts/test-consolidate-evidence.ps1
+++ b/skills/scripts/test-consolidate-evidence.ps1
@@ -1,0 +1,41 @@
+﻿#Requires -Version 5.1
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$root = (Resolve-Path (Join-Path $here "..\..")).Path
+$scratch = Join-Path $env:TEMP ("rs-consol-" + [guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Path (Join-Path $scratch "evidence") | Out-Null
+Copy-Item (Join-Path $root "examples\ctf-demo\evidence\E-001.md") (Join-Path $scratch "evidence\E-001.md")
+Copy-Item (Join-Path $root "examples\ctf-demo\evidence\E-002.md") (Join-Path $scratch "evidence\E-002.md")
+
+function Assert-FindingFields([string]$report) {
+    foreach ($f in @("confidence:","location:","evidence_ids:","status:")) {
+        if ($report -notmatch [regex]::Escape($f)) { throw "missing field $f" }
+    }
+    if ($report -match "evidence_refs:") { throw "legacy evidence_refs leaked" }
+}
+
+# Python path
+python (Join-Path $root "skills\scripts\consolidate_evidence.py") --case-root $scratch --evidence-ids "E-001,E-002" --finding-id F-CONSOL-1 --title "triage merge" --description "merged two triage notes" --severity info --status validated --confidence medium --location "see E-001 E-002" | Out-Null
+$r1 = Get-Content (Join-Path $scratch "report\report.md") -Raw
+Assert-FindingFields $r1
+$e1 = Get-Content (Join-Path $scratch "evidence\E-001.md") -Raw
+if ($e1 -notmatch "superseded by F-CONSOL-1") { throw "py did not mark superseded" }
+
+# reset for ps1
+Remove-Item (Join-Path $scratch "report") -Recurse -Force
+Copy-Item (Join-Path $root "examples\ctf-demo\evidence\E-001.md") (Join-Path $scratch "evidence\E-001.md") -Force
+Copy-Item (Join-Path $root "examples\ctf-demo\evidence\E-002.md") (Join-Path $scratch "evidence\E-002.md") -Force
+& (Join-Path $root "skills\scripts\consolidate-evidence.ps1") -CaseRoot $scratch -EvidenceIds "E-001,E-002" -FindingId F-CONSOL-2 -Title "triage merge ps1" -Description "merged two triage notes" -Severity info -Status validated -Confidence medium -Location "see E-001 E-002"
+$r2 = Get-Content (Join-Path $scratch "report\report.md") -Raw
+Assert-FindingFields $r2
+$e2 = Get-Content (Join-Path $scratch "evidence\E-001.md") -Raw
+if ($e2 -notmatch "superseded by F-CONSOL-2") { throw "ps1 did not mark superseded" }
+
+# review_case accepts superseded
+$demo = Join-Path $scratch "ctf"
+Copy-Item (Join-Path $root "examples\ctf-demo") $demo -Recurse
+python (Join-Path $root "skills\scripts\consolidate_evidence.py") --case-root $demo --evidence-ids "E-001" --finding-id F-001 --title "keep contract" --description "ok" --severity info --status validated --confidence medium --location "E-001" | Out-Null
+# F-001 already exists in ctf-demo report; just check parse of superseded evidence
+python (Join-Path $root "skills\case-review\scripts\review_case.py") $demo --verify-hashes 2>&1 | Select-Object -Last 8
+Write-Host "CONSOLIDATE_ALIGN_OK"
+Remove-Item $scratch -Recurse -Force


### PR DESCRIPTION
## Summary

Rebase of useful #114 onto current main, plus a field-alignment fix.

- Keep `superseded` / `superseded by F-xxx` in `review_case.py`
- Python and PowerShell now emit the **same** Finding fields required by case-review: `confidence`, `location`, `evidence_ids`
- Drop the PowerShell-only `evidence_refs` field
- Add `skills/scripts/test-consolidate-evidence.ps1`

## Why not merge #114 as-is

`review_case.py` requires Finding `evidence_ids` + `confidence` + `location`. The original `.ps1` wrote `evidence_refs` and omitted the other two, so a Windows-only consolidate would fail case-review.

## Local

- `test-consolidate-evidence.ps1` PASS
- `skills/case-review/tests/test_review_case.py` 8/8 OK

## Issues

Related to #62 (iOS evidence threshold) — **does not close #62**.

## Credit

Original: Yu-0312 in #114.