### PR TITLE
fix(case-init): reject unknown presets before writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - Create a functional Kali `proxycat` wrapper after installing the pinned source checkout
 - Scope PowerShell authorization fields to their contract sections and reject unsupported network modes in both guards
 - Reject unsupported network profiles during case initialization so invalid scopes are never emitted as ready
+- Reject unknown case presets in Bash and PowerShell before creating case artifacts, preventing mistyped presets from silently falling back to pending/offline defaults
 - Generate `skills/INDEX.md` from tracked skills only, excluding ignored local modules so clean-clone CI stays reproducible
 - Fail routing coherence when a configured skill is missing or only exists as an untracked local file
 

--- a/skills/scripts/case-init.ps1
+++ b/skills/scripts/case-init.ps1
@@ -76,7 +76,7 @@ if ($presetNormalized -in @('offline-sample', 'own-sample', 'local-sample')) {
     if ([string]::IsNullOrWhiteSpace($NetworkProfile)) { $NetworkProfile = 'lab_only' }
     if ([string]::IsNullOrWhiteSpace($EvidenceOfAuth)) { $EvidenceOfAuth = 'preset:own-system/lab' }
 } elseif (-not [string]::IsNullOrWhiteSpace($Preset)) {
-    Write-Host ("WARN: unknown -Preset '{0}' (allowed: offline-sample|ctf-public|own-system)" -f $Preset) -ForegroundColor Yellow
+    throw ("Invalid -Preset '{0}'. Allowed: offline-sample|ctf-public|own-system" -f $Preset)
 }
 
 if (-not $CaseName) {

--- a/skills/scripts/case-init.sh
+++ b/skills/scripts/case-init.sh
@@ -92,7 +92,8 @@ case "$PRESET" in
     EVIDENCE_OF_AUTH="${EVIDENCE_OF_AUTH:-preset:own-system/lab}"
     ;;
   *)
-    echo "WARN: unknown preset '$PRESET' (allowed: offline-sample|ctf-public|own-system)" >&2
+    echo "ERROR: invalid --preset '$PRESET' (allowed: offline-sample|ctf-public|own-system)" >&2
+    exit 2
     ;;
 esac
 

--- a/skills/scripts/test-bash-workflow.sh
+++ b/skills/scripts/test-bash-workflow.sh
@@ -23,23 +23,40 @@ if [ ! -f "$SCRATCH/work/test-bash-01/scope.md" ]; then
     exit 1
 fi
 
-# Test 2: case-guard.sh validates valid scope
-echo "[Test 2] case-guard.sh accepts valid scope"
+# Test 2: case-init.sh rejects unknown presets before writing artifacts
+echo "[Test 2] case-init.sh rejects unknown preset"
+invalid_preset_case="test-bash-invalid-preset"
+if bash "$SCRIPT_DIR/case-init.sh" \
+  --hint "invalid preset regression" \
+  --case-name "$invalid_preset_case" \
+  --project-root "$SCRATCH" \
+  --preset "definitely-not-valid" > /dev/null 2>&1; then
+    echo "FAIL: case-init accepted unknown preset"
+    exit 1
+fi
+
+if [ -e "$SCRATCH/work/$invalid_preset_case" ]; then
+    echo "FAIL: case-init wrote a partial case for unknown preset"
+    exit 1
+fi
+
+# Test 3: case-guard.sh validates valid scope
+echo "[Test 3] case-guard.sh accepts valid scope"
 if ! bash "$SCRIPT_DIR/case-guard.sh" --case-root "$SCRATCH/work/test-bash-01" > /dev/null; then
     echo "FAIL: case-guard rejected valid scope"
     exit 1
 fi
 
-# Test 3: case-guard.sh rejects invalid network mode
-echo "[Test 3] case-guard.sh rejects invalid network mode"
+# Test 4: case-guard.sh rejects invalid network mode
+echo "[Test 4] case-guard.sh rejects invalid network mode"
 sed -i 's/mode: authorized_target_only/mode: invalid_mode/g' "$SCRATCH/work/test-bash-01/scope.md"
 if bash "$SCRIPT_DIR/case-guard.sh" --case-root "$SCRATCH/work/test-bash-01" > /dev/null 2>&1; then
     echo "FAIL: case-guard accepted invalid network mode"
     exit 1
 fi
 
-# Test 4: case-guard.sh rejects ungranted auth
-echo "[Test 4] case-guard.sh rejects ungranted auth"
+# Test 5: case-guard.sh rejects ungranted auth
+echo "[Test 5] case-guard.sh rejects ungranted auth"
 sed -i 's/mode: invalid_mode/mode: authorized_target_only/g' "$SCRATCH/work/test-bash-01/scope.md"
 sed -i 's/status: granted/status: pending/g' "$SCRATCH/work/test-bash-01/scope.md"
 if bash "$SCRIPT_DIR/case-guard.sh" --case-root "$SCRATCH/work/test-bash-01" > /dev/null 2>&1; then

--- a/skills/scripts/test-p0-friction.ps1
+++ b/skills/scripts/test-p0-friction.ps1
@@ -366,7 +366,26 @@ if ($invalidNetworkProcess.ExitCode -ne 0 -and -not (Test-Path -LiteralPath $inv
     Bad 'case-init accepted unsupported network profile or wrote a partial case'
 }
 
-# 14b) CaseName must remain a single safe directory name under work/.
+# 14b) Unknown presets must fail before writing a partial case.
+$invalidPresetName = 'p0-invalid-preset-' + (Get-Date -Format 'HHmmss')
+$invalidPresetProcess = Start-Process -FilePath $HostExe -ArgumentList @(
+    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $ci,
+    '-Hint', 'invalid preset regression',
+    '-CaseName', $invalidPresetName,
+    '-PackageRoot', $PackageRoot,
+    '-Preset', 'definitely-not-valid'
+) -Wait -PassThru -WindowStyle Hidden
+$invalidPresetRoot = Join-Path $PackageRoot ("work\{0}" -f $invalidPresetName)
+if ($invalidPresetProcess.ExitCode -ne 0 -and -not (Test-Path -LiteralPath $invalidPresetRoot)) {
+    Ok 'case-init rejects unknown preset before writing case'
+} else {
+    Bad 'case-init accepted unknown preset or wrote a partial case'
+    if (Test-Path -LiteralPath $invalidPresetRoot) {
+        Remove-Item -LiteralPath $invalidPresetRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# 14c) CaseName must remain a single safe directory name under work/.
 $invalidCaseNames = @('..\case-escape', '../case-escape', 'case/name', 'case:name', '.. ', 'case.')
 $workRoot = Join-Path $PackageRoot 'work'
 foreach ($invalidCaseName in $invalidCaseNames) {


### PR DESCRIPTION
## Summary

- Reject unknown `--preset` values in the Bash and PowerShell case initializers before any case artifacts are written.
- Add Bash and Windows PowerShell regression coverage for fail-fast behavior and partial-case prevention.
- Document the behavior change in `CHANGELOG.md`.

## Problem

A typo in a non-empty preset previously emitted a warning but exited successfully. The initializer then continued with pending/offline defaults and created a case directory, making it easy to mistake a requested preset for an applied preset.

## Solution

Unknown presets now return a non-zero exit before the case directory is created. Existing aliases remain unchanged: `offline-sample`, `own-sample`, `local-sample`, `ctf-public`, `ctf`, `own-system`, and `lab-only`.

## Tests

- `bash skills/scripts/test-routing.sh` — 173/173 passed
- `bash skills/scripts/test-bootstrap-manifest.sh` — passed
- `bash skills/scripts/test-bash-workflow.sh` — passed
- `python3 skills/case-review/tests/test_review_case.py` — 8/8 passed
- JSON validation and `git diff --check` — passed