### PR TITLE
docs(changelog): fix backtick-escape corruption in Unreleased entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
-- **CI runs remaining unwired suites** — 	est-p0-friction.ps1 on the Windows leg of outing-tests (Windows PowerShell 5.1); case-review/tests/test_review_case.py in the Linux case-contract job. 	est-workflow-title-safety.ps1 was already wired.
+- **CI runs remaining unwired suites** — `test-p0-friction.ps1` on the Windows leg of `routing-tests` (Windows PowerShell 5.1); `case-review/tests/test_review_case.py` in the Linux `case-contract` job. `test-workflow-title-safety.ps1` was already wired.
 
 ### Fixed
 - **Windows PowerShell 5.1 encoding** — added a UTF-8 BOM to five non-ASCII `.ps1` scripts (`skills/scripts/verify-doc-facts.ps1`, `apk-reverse/scripts/frida-run.ps1`, `apk-reverse/scripts/rebuild-sign-install.ps1`, `ida-reverse/scripts/start.ps1`, `radare2/scripts/recon.ps1`). Without a BOM, PS 5.1 parses these files as the system ANSI codepage and garbles their Chinese / em-dash string literals; `verify-doc-facts.ps1` was failing four checks under 5.1 (CI only ran it under `pwsh`, which defaults to UTF-8). CI now guards every non-ASCII `.ps1` for a BOM.


### PR DESCRIPTION
The [Unreleased] > Added bullet introduced in #111 was written via PowerShell double-quote interpolation, which consumed every backtick: backtick-t rendered as a literal TAB and backtick-r as a CR, leaving control characters and mangled tokens ('outing-tests', TAB+'est-p0-friction', TAB+'est-workflow-title-safety'). This restores the intended inline-code backticks and removes the stray TAB/CR — git now recognizes CHANGELOG.md as text again. One-line change.