### PR TITLE
fix(docs): guard internal Markdown links; drop a dead reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,10 @@ jobs:
         shell: bash
         run: python3 skills/case-review/tests/test_review_case.py
 
+      - name: Internal Markdown links resolve
+        shell: bash
+        run: python3 skills/scripts/verify-doc-links.py
+
   version-check:
     name: version consistency
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **CI runs remaining unwired suites** — 	est-p0-friction.ps1 on the Windows leg of outing-tests (Windows PowerShell 5.1); case-review/tests/test_review_case.py in the Linux case-contract job. 	est-workflow-title-safety.ps1 was already wired.
 
 ### Fixed
+- **Broken internal doc link + guard** — removed a dangling `phishing-case-study.md` reference in `skills/reverse-engineering/field-notes.md` (the file was never created; the analysis is inline). Added `skills/scripts/verify-doc-links.py`, wired into the `case-contract` job, so CI fails on any internal Markdown link that does not resolve to a tracked file (fenced code, the generated `tool-index.md`, and the vendored `src-hunter` corpus are excluded).
 - **Windows PowerShell 5.1 encoding** — added a UTF-8 BOM to five non-ASCII `.ps1` scripts (`skills/scripts/verify-doc-facts.ps1`, `apk-reverse/scripts/frida-run.ps1`, `apk-reverse/scripts/rebuild-sign-install.ps1`, `ida-reverse/scripts/start.ps1`, `radare2/scripts/recon.ps1`). Without a BOM, PS 5.1 parses these files as the system ANSI codepage and garbles their Chinese / em-dash string literals; `verify-doc-facts.ps1` was failing four checks under 5.1 (CI only ran it under `pwsh`, which defaults to UTF-8). CI now guards every non-ASCII `.ps1` for a BOM.
 
 ### Changed

--- a/skills/reverse-engineering/field-notes.md
+++ b/skills/reverse-engineering/field-notes.md
@@ -408,7 +408,6 @@ print(f"admin_session={payload_b64}.{sig_b64}")
 ## Web Phishing Infrastructure
 
 ### Phishing Panel: {target_domain_a} / {target_domain_b}
-**完整分析**: [phishing-case-study.md](phishing-case-study.md)
 
 Two-server phishing infrastructure impersonating a government agency. Full victim control system with server-driven status code redirection.
 

--- a/skills/scripts/verify-doc-links.py
+++ b/skills/scripts/verify-doc-links.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Verify internal (relative) Markdown links resolve to tracked files.
+
+Guard against broken cross-references in the repo's documentation. Only
+*local* links are checked: `http(s)`, `mailto:`, `tel:`, protocol-relative,
+and pure `#anchor` links are ignored, as are links inside fenced code blocks
+(``` / ~~~) and the generated `tool-index.md`. Link targets are resolved
+relative to the containing file and matched against the set of git-tracked
+files and directories (UTF-8 paths, so CJK filenames compare correctly).
+
+Exit 1 (with a report) if any internal link points at a path that is not
+tracked. Run from the repo root:  python3 skills/scripts/verify-doc-links.py
+
+The vendored `src-hunter` payload knowledge base is skipped: it is an
+imported corpus with its own index/accounting (and gets AV-quarantined on
+Windows clones), so its link completeness is maintained upstream, not here.
+"""
+import os
+import re
+import subprocess
+import sys
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+INLINE_CODE = re.compile(r"`[^`]*`")
+FENCE = re.compile(r"^\s*(```|~~~)")
+SKIP_PREFIX = ("http://", "https://", "mailto:", "tel:", "ftp:", "data:", "//", "#")
+SKIP_CHARS = set("{}<>`$*|")
+# Vendored corpora excluded from link-hygiene (maintained upstream).
+EXCLUDE_DIRS = ("skills/pentest-tools/src-hunter/",)
+
+
+def tracked_paths():
+    out = subprocess.run(
+        ["git", "-c", "core.quotePath=false", "ls-files", "-z"],
+        capture_output=True, check=True,
+    ).stdout.decode("utf-8")
+    files = {os.path.normpath(p).replace(os.sep, "/") for p in out.split("\0") if p}
+    dirs = set()
+    for f in files:
+        d = os.path.dirname(f)
+        while d and d not in dirs:
+            dirs.add(d)
+            d = os.path.dirname(d)
+    return files, dirs
+
+
+def links_in(path):
+    """Yield (lineno, target) for local links outside fenced code blocks."""
+    in_fence = False
+    try:
+        fh = open(path, encoding="utf-8")
+    except OSError:
+        return  # unreadable tracked file (e.g. quarantined locally); nothing to scan
+    with fh:
+        for lineno, line in enumerate(fh, 1):
+            if FENCE.match(line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            for m in LINK.finditer(INLINE_CODE.sub("", line)):
+                raw = m.group(1).strip().strip("<>")
+                if not raw:
+                    continue
+                target = raw.split()[0].split("#")[0].split("?")[0]
+                if not target:
+                    continue
+                if target.lower().startswith(SKIP_PREFIX):
+                    continue
+                if "tool-index" in target or SKIP_CHARS & set(target):
+                    continue
+                yield lineno, target
+
+
+def resolve(md, target):
+    if target.startswith("/"):
+        base = target.lstrip("/")
+    else:
+        base = os.path.join(os.path.dirname(md), target)
+    return os.path.normpath(base).replace(os.sep, "/")
+
+
+def main():
+    files, dirs = tracked_paths()
+    broken = []
+    mds = sorted(
+        p for p in files
+        if p.endswith(".md") and not p.startswith(EXCLUDE_DIRS)
+    )
+    for md in mds:
+        for lineno, target in links_in(md):
+            p = resolve(md, target)
+            if p not in files and p not in dirs:
+                broken.append((md, lineno, target))
+
+    if broken:
+        print(f"FAIL verify-doc-links: {len(broken)} broken internal link(s)")
+        for md, lineno, target in broken:
+            print(f"  {md}:{lineno} -> {target}")
+        return 1
+    print("OK verify-doc-links: all internal Markdown links resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds skills/scripts/verify-doc-links.py, wired into the case-contract CI job, which fails on any internal Markdown link that does not resolve to a git-tracked file. It skips fenced code blocks, the generated tool-index.md, external/anchor links, and the vendored src-hunter payload corpus (imported knowledge base with its own accounting, and AV-quarantined on Windows clones). Also removes a dangling phishing-case-study.md reference in skills/reverse-engineering/field-notes.md whose target was never created — the analysis is inline. Verified against all 440 tracked .md files (reading git blobs): 0 broken links outside the excluded corpus. Note for maintainer: payloader/index.md still lists tools/反弹shell.md, which was never committed but is counted in the index totals (14 categories / 114 entries) — that looks like a genuinely missing vendored file to restore, so I left it out of the guard's scope rather than delete the row.