### PR TITLE
test(ci): fix and wire evidence-consolidation + codex-encoding suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
         shell: powershell
         run: ./skills/scripts/test-client-neutral-bootstrap.ps1
 
+      - name: Codex config encoding (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: ./skills/scripts/test-bootstrap-codex-encoding.ps1
+
+      - name: Evidence consolidation py/ps1 parity (Windows PowerShell 5.1)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: ./skills/scripts/test-consolidate-evidence.ps1
+
       - name: Offline sample case contract (Windows PowerShell 5.1)
         if: runner.os == 'Windows'
         shell: powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - **Windows PowerShell 5.1 encoding** — added a UTF-8 BOM to five non-ASCII `.ps1` scripts (`skills/scripts/verify-doc-facts.ps1`, `apk-reverse/scripts/frida-run.ps1`, `apk-reverse/scripts/rebuild-sign-install.ps1`, `ida-reverse/scripts/start.ps1`, `radare2/scripts/recon.ps1`). Without a BOM, PS 5.1 parses these files as the system ANSI codepage and garbles their Chinese / em-dash string literals; `verify-doc-facts.ps1` was failing four checks under 5.1 (CI only ran it under `pwsh`, which defaults to UTF-8). CI now guards every non-ASCII `.ps1` for a BOM.
+- **Evidence-consolidation test fixed + two suites wired into CI** — `test-consolidate-evidence.ps1` printed its success marker but leaked exit 1: it ran `review_case.py --verify-hashes` on a case whose consolidation had (by design) rewritten `E-001.md`, so hash fixity could never pass. Dropped `--verify-hashes`, added an explicit exit-code assertion, and wired both it and `test-bootstrap-codex-encoding.ps1` into the Windows leg of `routing-tests` (both shipped in the repo but were never run by CI).
 
 ### Changed
 - **Coherence clamp (identity-preserving)** — `RULES.md` hot path is `master-route` → `case-init` → PRIMARY. `routing.json` remains the only route table; `MASTER-ROUTING.md` priority order is verified against JSON. `routing.md` is advisory. `precedent-auth.md` no longer grants auth.

--- a/skills/scripts/test-consolidate-evidence.ps1
+++ b/skills/scripts/test-consolidate-evidence.ps1
@@ -35,7 +35,10 @@ if ($e2 -notmatch "superseded by F-CONSOL-2") { throw "ps1 did not mark supersed
 $demo = Join-Path $scratch "ctf"
 Copy-Item (Join-Path $root "examples\ctf-demo") $demo -Recurse
 python (Join-Path $root "skills\scripts\consolidate_evidence.py") --case-root $demo --evidence-ids "E-001" --finding-id F-001 --title "keep contract" --description "ok" --severity info --status validated --confidence medium --location "E-001" | Out-Null
-# F-001 already exists in ctf-demo report; just check parse of superseded evidence
-python (Join-Path $root "skills\case-review\scripts\review_case.py") $demo --verify-hashes 2>&1 | Select-Object -Last 8
+# F-001 already exists in ctf-demo report; just check the case still PARSES with
+# superseded evidence. --verify-hashes cannot pass here by design: consolidation
+# rewrites E-001.md (adds the superseded marker), which changes its SHA-256.
+$review = python (Join-Path $root "skills\case-review\scripts\review_case.py") $demo 2>&1 | Select-Object -Last 8
+if ($LASTEXITCODE -ne 0) { throw "review_case failed to parse consolidated case:`n$($review -join [Environment]::NewLine)" }
 Write-Host "CONSOLIDATE_ALIGN_OK"
 Remove-Item $scratch -Recurse -Force


### PR DESCRIPTION
Two test scripts ship in the repo but CI never runs them. test-consolidate-evidence.ps1 was also broken: it printed CONSOLIDATE_ALIGN_OK yet exited 1, because its final step ran review_case.py --verify-hashes on a case whose consolidation had (by design) rewritten E-001.md — so SHA-256 fixity could never pass — and it never checked that native exit code. Confirmed: exit 1 with --verify-hashes, exit 0 without. Fix drops the incompatible flag and adds an explicit exit-code assertion (parse check, the test's stated intent). Then wires both this and test-bootstrap-codex-encoding.ps1 (UTF-8/BOM/CRLF preservation for the Codex TOML config) into the Windows leg of routing-tests under shell: powershell, matching the existing Windows-only PS 5.1 test steps. Both exit 0 locally under Windows PowerShell 5.1.