### PR TITLE
docs(field-journal): record August RE notes and local IDA MCP usage

### DIFF
--- a/skills/field-journal/2026-08-13_hww-deep-d-red-trust.md
+++ b/skills/field-journal/2026-08-13_hww-deep-d-red-trust.md
@@ -1,0 +1,6 @@
+# 2026-08-13 DEEP-D RED-TRUST (own LIVE)
+
+- own_system static T0/T1 on customer ProgramData PEs
+- HMAC ASCII salt still decode+HMAC in GUI/engine
+- GUI update_gate unexpected-Err leaves gate open
+- MA-R2: in-process engine subset vs spawn; byovd/DSE/iqvw/Nal engine-only

--- a/skills/field-journal/2026-08-13_hww-v217-ida-red-defensive.md
+++ b/skills/field-journal/2026-08-13_hww-v217-ida-red-defensive.md
@@ -1,0 +1,25 @@
+# 2026-08-13 HWW v2.17.2 LIVE IDA 红队（自有产品 · 防御）
+
+- 目标：自有 HWW LIVE pin `2B5C8A75` + dist/ProgramData 客户 PE
+- PRIMARY：ida-reverse；auth=granted / own_system / offline
+- 不做：驱动重建/加载、exploit PoC、commit
+
+## 复用
+
+- IDA session `hwwv2drv`（driver\v2\HwwV2.sys）
+- ProgramData LIVE：`hww-launcher-live` / `hww-gui-live` / `hww-engine-live`
+- 先验 dump：`work/hww-v217-defensive-re\`（未再 unpack）
+
+## 有效做法
+
+- `start.ps1` + `open.ps1` 拉起 worker；`idb_list` 复用已开库
+- 大 PE 用 `survey_binary(minimal)` + `find_regex`；驱动用 `analyze_function`/`decompile`
+- `find_regex` 不要写 `\\.`（re 会报 missing {）
+- idalib max-workers=4：第 5 个 open 会失败，先关旧 session
+
+## 结论摘要
+
+- 2B5C8A75：OEM / SOFTWARE\HWW / NIC allowlist 明文已不在；F03 IOC 与 APC 注入路径仍在
+- LIVE GUI：iqvw/byovd 字符串 0；HMAC 盐 ASCII 仍在（HYN-005）
+- LIVE engine：DSE 剧本字符串仍在（0 xref）；hard-remint 是新披露面
+- LIVE launcher：8×MZ + 契约 JSON + build-identity + iqvw PDB

--- a/skills/field-journal/2026-08-13_hww-v217-ida-red-followup.md
+++ b/skills/field-journal/2026-08-13_hww-v217-ida-red-followup.md
@@ -1,0 +1,19 @@
+# 2026-08-13 HWW v2.17.2 LIVE IDA 红队 follow-up（四问闭合）
+
+- 案件：`work/hww-v217-defensive-re` auth=granted
+- PRIMARY：ida-reverse；不开驱动、无 PoC、无仓库改动
+- 复用：`hww-launcher-live` / `hww-gui-live` / `hww-engine-live`；`idb_close hwwv2drv` 后 `open.ps1` → `hww-wmiprv-live`
+
+## 有效做法
+
+- worker=4 满时先关本轮不用的 `hwwv2drv`
+- 嵌套 MZ：`find_bytes 4D 5A 90 00` 得 8 VA → VA→fileoff → PE SizeOfRawData 与契约 size 分别 SHA
+- iqvw 双 SHA = 26624（无 overlay）vs 34568（+7944 Authenticode）
+- rust 静态串：`xrefs_to` 为 0 时再 `find_bytes` 64-bit fat-ptr；仍 0 则判 dead .rdata
+
+## 四问结论
+
+1. wmiprv `7EBBDCC7`：cloak 路径 LIVE；`CIMWIN32_LOAD` 0 xref leftover
+2. F15：嵌套 iqvw **就是** 契约 pin `4429F32D` / 34568
+3. DSE `@0x1403a2788`：0 xref / 0 fat-ptr / 0 listing → dead 但仍链入
+4. GUI sticky env blob 与 `Desktop\spoofer\crates\hww-gui-tauri` 均在

--- a/skills/field-journal/2026-08-16_deltaforce-full-engineering-re-pass1.md
+++ b/skills/field-journal/2026-08-16_deltaforce-full-engineering-re-pass1.md
@@ -1,0 +1,60 @@
+# [RE] Delta Force 全量工程逆向 Pass-1（本地安装）
+
+## 任务类型
+二进制分析 / 启动链 / 壳 / 反作弊全栈静态测绘
+
+## 目标描述
+对 `E:\LP game\Delta Force` 做不排除组件的工程逆向：Bootstrap、Shipping、TenProtect6、ACE UM+内核多变体、SGuard、launcher、pak 元数据。用户明确要求「按照工程不进行排除」。
+
+## Scope 摘要（已脱敏）
+- auth_basis: own_system
+- network_profile: offline
+- asset_types: [ue4-shipping, tpshell, ace-um, ace-sys, sguard, launcher, pak-meta]
+
+## 角色
+- lead_role: lead
+- specialists: [cre, cie]
+
+## 实际执行路径
+1. master-route → reverse-engineering R0
+2. case-init + scope 全安装树
+3. rabin2 PE triage / 哈希 / Authenticode
+4. ACE 34 文件清单 + 驱动字符串设备面
+5. 节表确认 .tvm0 / .std / .detourd
+6. findings + report + architecture
+
+## Evidence 链摘要
+| E-id | source_type | 可复用模式 | Finding |
+|------|-------------|------------|---------|
+| E-001 | hash+sig | 发行商三分 | F-004 |
+| E-003 | pe-import | Shipping 第一导入 = 壳 | F-002 |
+| E-008/E-013 | export+section | 单导出 + .tvm0 + 零字符串 | F-002 |
+| E-009 | driver-strings | 设备名 + notify/Ob/Flt | F-003 |
+| E-010 | um-export | InitAceClient 族 | F-003 |
+| E-015 | idw | D3D12 函数地址采集 | F-003 |
+
+## Finding / Path
+- top: TenProtect6 强制入口 + ACE 全栈并行，二者均 .tvm0
+- path: stub → Shipping → TPShell!1 → UE；ACE Base/CORE/GAME/SSC 内核旁路
+
+## 踩坑
+| 现象 | 原因 | 正确做法 |
+|------|------|----------|
+| case-guard offline fail | 缺 offline sample cue | scope 写明 offline_sample 路径 |
+| Get-ChildItem -Include 无结果 | 无 -Recurse | Where-Object Extension |
+| ShippingBase -zz 空 | VM/加密 | 看节表 .tvm0 而非 strings |
+| 初版 scope 排除 AC | 用户要求不排除 | 立即改 scope 全量分析 |
+
+## 工具链
+- rabin2 6.2.0 @ C:\Users\Harry_win10\Tools\radare2\bin\rabin2.exe
+- reverse-skill case scripts
+
+## 本次未执行（列入 W9+）
+- IDA 打开 TPShell / ACE-Base64 / ACE-BASE.sys
+- 运行时设备枚举与 IOCTL 探测
+- pak 解包
+- 动态进程树
+
+## 可复用模式
+- 腾讯系 UE 射击：ShippingBase 文件名伪装 + TPShell64 PDB + .tvm0
+- ACE 驱动：固定 BASE/GAME + CORE 动态设备名模板 + 多 sys 变体同树分发

--- a/skills/field-journal/2026-08-16_ue4-wegame-tenprotect-ace-inventory.md
+++ b/skills/field-journal/2026-08-16_ue4-wegame-tenprotect-ace-inventory.md
@@ -1,0 +1,71 @@
+# [RE] UE4 Global client + WeGame + TenProtect6 + ACE inventory
+
+## 任务类型
+二进制分析 / 安装盘点
+
+## 目标描述
+对本地已安装的 UE4 射击客户端做离线静态架构盘点：启动链、签名主体、TenProtect 壳、ACE 组件清单。不碰反作弊绕过、不挂钩、不连正式服。
+
+## Scope 摘要（已脱敏）
+- auth_basis: own_system
+- network_profile: offline
+- asset_types: [ue4-shipping-exe, wegame-launcher, tenprotect-shell, ace-um, ace-sys]
+
+## 角色
+- lead_role: lead
+- specialists: [cre, cie]
+
+## 实际执行路径
+1. master-route → reverse-engineering (R0)
+2. case-init + 用户口头授权
+3. 目录树 / pak 体量 / Win64 SDK 列表
+4. rabin2 -I/-i/-l + FileVersion + Authenticode + SHA256
+5. ACE 目录清单（UM + 4 个内核映像，不做 IOCTL）
+6. 架构图 + findings
+
+## Evidence 链摘要（已脱敏）
+| E-id | source_type | 可复用分析模式 | 关联 Finding |
+|------|-------------|----------------|--------------|
+| E-001 | authenticode+sha256 | 发行商三分：游戏公司 / ACE 厂商 / WHQL | F-004 |
+| E-002 | pe-triage | Shipping 第一导入 = TPShell64 ordinal 1 | F-002 |
+| E-003 | dir-inventory | ACE 28.5 + SGuard + BASE/CORE/GAME/SSC-DRV | F-003 |
+| E-004 | launch-chain | UE Bootstrap stub CreateProcessW + WeGame PaaS 双入口 | F-001 |
+
+## Finding / Path 摘要
+- top_finding: TenProtect6 是 Shipping.exe 的第一静态依赖；ACE 是旁路服务/驱动树而非 PE import
+- path_type: callflow
+- path_one_liner: stub/launcher → Shipping.exe → TPShell64!1 → UE4/Sail/CEF; ACE Service+sys 并行驻留
+
+## 踩坑记录
+| 现象 | 原因 | 正确做法 | 耗时 |
+|------|------|---------|------|
+| rabin2 -I 扫 526MB Shipping 可接受 | 不要对 Shipping 跑全量 -zz | 只对 stub/shell 抽字符串 | 短 |
+| INTLConfig.ini.new 当 ini 读 | 已混淆 | 标成 blob，不要当配置解析 | 短 |
+| ACE-Service rabin2 signed=false | 安全目录解析与 Authenticode 不一致 | 以 Get-AuthenticodeSignature 为准 | 短 |
+
+## 工具链使用
+- rabin2 6.2.0（tool-index 绝对路径）
+- Get-FileHash / Get-AuthenticodeSignature / FileVersionInfo
+- 未用 IDA/Frida（offline pass 1）
+
+## 关键命令/代码
+```
+rabin2 -I -l -i <pe>
+rabin2 -zz DeltaForceClient.exe
+Get-FileHash -Algorithm SHA256
+Get-AuthenticodeSignature
+```
+
+## 对技能包的改进建议
+- R0 对「已安装 UE 游戏目录」足够；若用户只要反作弊清单可加一条 ACE/TenProtect 关键词到 MASTER-ROUTING
+- 不必上 pwn-chain / edr-bypass-re（本任务明确排除绕过）
+
+## 可复用的模式/脚本片段
+- 游戏安装盘点顺序：root stub → Binaries/Win64 → 第一导入 DLL 的 PDB → AntiCheat* 目录 → Authenticode 分组
+- ShippingBase 文件名像游戏模块，PDB/导出名才暴露 TenProtect
+
+## 本次未执行
+- IDA 打开 Shipping / TPShell
+- ACE 驱动 IOCTL / 回调枚举
+- pak 解包
+- 动态进程树

--- a/skills/field-journal/2026-08-20_tpshell-a35f4-store-add-imm.md
+++ b/skills/field-journal/2026-08-20_tpshell-a35f4-store-add-imm.md
@@ -1,0 +1,62 @@
+# 2026-08-20 TPShell 0x1821A35F4 STORE.ADD.IMM.DW
+
+## 场景分类
+二进制分析 / 自定义 VM opcode
+
+## 目标概述
+离线 Capstone+Unicorn 分类 leftover UNK `0x1821A35F4`（rec124 @ip=24）。
+
+## Scope 摘要（脱敏）
+- auth_basis: own_system
+- network_profile: offline
+- asset_types: [memory-dump, custom-vm]
+
+## 角色
+- lead_role: lead
+- specialists: [cre, cie]
+
+## 完整执行链路
+
+1. `parse_records` + `exec_chain` 锚定 UNK `@ip=24` leftover `aedb532ffb5d2698da8de41a`。
+2. 零 seed INV@0；FAKE 页完成 consume=12。
+3. 逐 u16 `{0,0xFFFF,0x1234}` 证明 word MBA ≡ XOR；imm dword `{0,0xFFFFFFFF,0x12345678,real}` ≡ XOR。
+4. L2 `{0,0xFFFFFFFF,0x12345678,real}` 证明 `(~dw)-0xE51BAF47`，不是 XOR；real → HANDLER0。
+5. 只信 live helper `0x182072214` / tail `0x181F9E74C`，不抄首个 `jmp` 后的线性死码。
+
+## Evidence 链摘要（脱敏）
+
+| E-id | severity | status | source_type | 可复用命令模式 | 关联 Finding |
+|------|----------|--------|-------------|----------------|--------------|
+| E-lift-a35f4 | info | validated | command | `python scripts/prove_a35f4.py` | F-unk-a35f4 |
+
+## Finding / Path 摘要
+- top_finding: STORE.ADD.IMM.DW `[sa+sb]=imm32`；L2 `(~dw)-0xE51BAF47`；next HANDLER0
+- path_type: solve
+- path_one_liner: leftover UNK → FAKE consume/keys → live-island L2 → paste-ready `disp_a35f4` / `if h==`
+
+## 踩坑记录
+
+| 问题 | 原因 | 解决方案 | 耗时 |
+|------|------|---------|------|
+| consume=0 INV@0 | src 是指针，`[0]` 未映射 | vreg `0x380`/`0xE8` seed 成 FAKE 再 sweep | 短 |
+| rec59 同 MOV.QW6 易混 next | 那条 leftover 去已接线 `0x1820DB12A` | rec124 L2 `0x1AE48DDA` 单独证明 → H0 | 短 |
+| 单独 exec_chain v62=0 | 8580 共享 vreg；fresh rem 无前置写入 | 顺序走 rec0..124 再读槽 | 短 |
+
+## 工具链发现
+- Python 3.12 + Capstone + Unicorn；dump `TPShell64_memdump.dll`；不改 `hybrid_vm.py`
+
+## 关键代码/命令
+
+```
+python scripts/lift_a35f4.py
+python scripts/prove_a35f4.py
+python scripts/snippets_a35f4.py
+```
+
+## 对本包的改进建议
+- 无
+
+## 可复用的模式/脚本片段
+- 指针 opcode：FAKE 页 + dest retarget
+- L2：`next = H + sext32(mba)`；先试 XOR/ADD/~dw+K，再看 live island
+- word：`0/0xFFFF/0x1234` 必做；L2：`0/0xFFFFFFFF/0x12345678+real` 必做且不预设 XOR

--- a/skills/field-journal/2026-08-20_tpshell-follow-unk-opcode-lift.md
+++ b/skills/field-journal/2026-08-20_tpshell-follow-unk-opcode-lift.md
@@ -1,0 +1,64 @@
+# 2026-08-20 TPShell leftover UNK follower lift
+
+## 场景分类
+二进制分析 / 自定义 VM opcode
+
+## 目标概述
+离线 Capstone+Unicorn 分类三条 leftover UNK follower（ORADD.NOT / LOADZX.DW.PTR / STORE.ADD.QW），恢复 word XOR 与 L2 MBA。
+
+## Scope 摘要（脱敏）
+- auth_basis: own_system
+- network_profile: offline
+- asset_types: [memory-dump, custom-vm]
+
+## 角色
+- lead_role: lead
+- specialists: [cre, cie]
+
+## 完整执行链路
+
+1. `parse_records` + `exec_chain` 锚定 UNK `@ip` 与 leftover hex。
+2. Unicorn 停在 `48 8B 55 60` / HANDLER0；指针类 opcode 用 FAKE 页完成 consume。
+3. 逐 u16 打补丁 `{0,0xFFFF,0x1234}` 证明 word MBA ≡ XOR。
+4. 打补丁 L2 `{0,0xFFFFFFFF,0x12345678,real}`；next 取最后一跳寄存器 jmp（未映射也算）。
+5. 只信 live helper 上的 MBA，不抄首个 `jmp` 后的线性死码。
+
+## Evidence 链摘要（脱敏）
+
+| E-id | severity | status | source_type | 可复用命令模式 | 关联 Finding |
+|------|----------|--------|-------------|----------------|--------------|
+| E-lift-follow-new3 | info | validated | command | `python scripts/prove_follow_new3.py` | F-unk-follow-3 |
+
+## Finding / Path 摘要
+- top_finding: 三条 follower 已分类；H3 L2 为 `(dw-K1)^K2`，H1/H2 L2 可折叠为 XOR
+- path_type: solve
+- path_one_liner: leftover UNK → Unicorn consume/keys → live-island L2 → paste-ready `disp_*` / `if h==`
+
+## 踩坑记录
+
+| 问题 | 原因 | 解决方案 | 耗时 |
+|------|------|---------|------|
+| H2/H3 consume=0 INV | src 是指针，`[0]` 未映射 | 把 vreg 槽位 seed 成 FAKE 再 sweep L2/dest | 短 |
+| L2 next=None | 未映射 fetch 时只记了异常 | 用最后一次 `jmp r*` 目标当 next | 短 |
+| 线性反汇编像第三条 word MBA | 首个 `jmp` 后是死码 | 跟 Unicorn flow / helper land | 短 |
+
+## 工具链发现
+- Python 3.12 + Capstone + Unicorn；dump `TPShell64_memdump.dll`；不改 `hybrid_vm.py`
+
+## 关键代码/命令
+
+```
+python scripts/lift_follow_new3.py
+python scripts/prove_follow_new3.py
+```
+
+## 对本包的改进建议
+- 路由 PRIMARY 落到 dsl-vm-reverse（JS VM）是误匹配；native leftover VM 应走 reverse-engineering / ida-reverse。无需改 routing（hint 含 dest-env 已足够）。
+
+## 可复用的模式/脚本片段
+- 指针 opcode：FAKE 页 + dest retarget
+- L2：`next = H + sext32(mba)`；先试 XOR/ADD/NOTADD，再看 live island
+- word：`0/0xFFFF/0x1234` 必做；L2：`0/0xFFFFFFFF/0x12345678+real` 必做且不预设 XOR
+
+## 进化动作
+- [x] 无需更新（routing 误匹配已记录，不改共享矩阵）

--- a/skills/field-journal/_index.md
+++ b/skills/field-journal/_index.md
@@ -6,10 +6,10 @@
 
 ## 统计
 
-- 真实项目数：21
+- 真实项目数：28
 - 种子参考数：17
-- 总条目数：38
-- 最近更新：2026-09-03
+- 总条目数：45
+- 最近更新：2026-09-04
 
 ## 按场景分类
 
@@ -21,6 +21,13 @@
 
 ### 二进制 / 固件 / CTF
 
+- [2026-08-20_tpshell-a35f4-store-add-imm](./2026-08-20_tpshell-a35f4-store-add-imm.md)
+- [2026-08-20_tpshell-follow-unk-opcode-lift](./2026-08-20_tpshell-follow-unk-opcode-lift.md)
+- [2026-08-16 Delta Force 全量工程逆向 Pass-1](./2026-08-16_deltaforce-full-engineering-re-pass1.md)
+- [2026-08-16 UE4 WeGame TenProtect ACE 盘点](./2026-08-16_ue4-wegame-tenprotect-ace-inventory.md)
+- [2026-08-13 HWW v2.17 IDA 红队防御](./2026-08-13_hww-v217-ida-red-defensive.md)
+- [2026-08-13 HWW v2.17 IDA 红队 follow-up](./2026-08-13_hww-v217-ida-red-followup.md)
+- [2026-08-13 HWW DEEP-D RED-TRUST](./2026-08-13_hww-deep-d-red-trust.md)
 - [2026-08-06_cortex-m-msc-firmware-self-keyed-rotate-xor](./2026-08-06_cortex-m-msc-firmware-self-keyed-rotate-xor.md)
 - [2026-07-22 Electron Bytenode 特权更新链分析](./2026-07-22_electron-bytenode-privileged-update-chain.md)
 - [2026-07-14_android-arm64-self-extract-source-recovery](./2026-07-14_android-arm64-self-extract-source-recovery.md)

--- a/skills/ida-reverse/IDA-MCP-USAGE.md
+++ b/skills/ida-reverse/IDA-MCP-USAGE.md
@@ -1,0 +1,54 @@
+# IDA MCP 用法（本机约定）
+
+单一入口：`idapro` → `http://127.0.0.1:13337/mcp`  
+启动：`skills/ida-reverse/scripts/start.ps1`（`--unsafe`，无 `ext=dbg`）  
+卡住 / Cursor `user-idapro` error：`scripts/recover.ps1`。每分钟 `watchdog.ps1` 会自己拉起；supervisor 死锁超过 3 分钟也会 `-Force`。
+
+## 不要做
+
+- 不要再配第二个 IDA MCP（`ida-pro-mcp`、blacktop、iida、stdio 第二套 supervisor）
+- 不要 `?ext=dbg`，不要 attach / DebugActiveProcess（ACE 起来后）
+- 不要 Hex-Rays `0x183B04ECC`；leftover INTERP CFF 失败时改用磁盘 Capstone / persist emu
+- 不要把 NameDB needle 当 dest-env 成功条件
+
+## 工具怎么选
+
+| 目的 | 工具 |
+|---|---|
+| 开库 / 列会话 | `idb_open` / `idb_list`（大文件优先 `open.ps1`） |
+| 伪代码 | `decompile`；CFF 失败不要死磕 |
+| 建函数 | `define_func` + `define_code` |
+| 搜字节 / 指令 | `find_bytes` / `insn_query` |
+| 任意 VA 线性反汇编、批量普查 | **`py_eval` / `py_exec_file`** |
+| 写 IDB 注释 | `set_comments` / `rename` |
+
+## py_eval 模板
+
+`database` 必填（`idb_list` 的 session_id）。
+
+```python
+# 任意 VA 线性 20 条（不要求已是函数）
+import idc
+ea = 0x180065132
+rows = []
+for _ in range(20):
+    rows.append(f"{ea:#x} {idc.generate_disasm_line(ea, 0)}")
+    nxt = idc.next_head(ea)
+    if nxt == idc.BADADDR: break
+    ea = nxt
+result = "\n".join(rows)
+```
+
+```python
+# 批量 define_func
+import ida_funcs
+for ea in (0x181EF2460, 0x181DD7ED0):
+    ida_funcs.add_func(ea)
+result = "ok"
+```
+
+长脚本用 `py_exec_file`（绝对路径），不要把几百行塞进 py_eval。
+
+## 大 .tvm0
+
+MCP `decompile` 巨函数会炸。需要归档时用 IDA-NO-MCP **导出文件**（`inp` / Ctrl-Shift-E），不要再挂一个 MCP。


### PR DESCRIPTION
## Summary
- Add seven August field-journal writeups: HWW defensive IDA passes, UE4/WeGame/TenProtect/ACE inventory, and TPShell leftover opcode lifts.
- Update `skills/field-journal/_index.md` counts from 21/38 to 28/45 and link the new notes under binary/firmware.
- Add `skills/ida-reverse/IDA-MCP-USAGE.md` so later sessions reuse the single local `idapro` entry, recover, and watchdog path.

## Test plan
- [ ] Open each new link from `skills/field-journal/_index.md` and confirm the files render.
- [ ] Skim the notes for leftover machine-local secrets; case paths are already marked redacted / own_system / offline.
- [ ] Docs-only change: no routing, script, or CI updates required.
