### PR TITLE
test(routing): add bilingual R40 case-review benchmark cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **CI runs remaining unwired suites** — `test-p0-friction.ps1` on the Windows leg of `routing-tests` (Windows PowerShell 5.1); `case-review/tests/test_review_case.py` in the Linux `case-contract` job. `test-workflow-title-safety.ps1` was already wired.
 - **Binary Ninja route and skill** — added `binary-ninja-reverse` for HLIL/MLIL/LLIL, Python API, and an explicitly enabled loopback community MCP bridge; Binary Ninja remains a manual commercial dependency.
 - **Optional Codex adapter plugin** — added `plugins/reverse-skill/` without changing the client-neutral core or auto-registering MCP servers.
+- **Benchmark coverage for R40 (case-evidence-review)** — the route had a single English case; added three cases covering its previously-untested branches (Chinese `证据链`/`证据图`/`可追溯性`/`案件审查`/`案例审计`, and English `evidence.?graph`/`fixity.?check`/`case.?audit`), each verified through both the PowerShell and Bash routers.
 
 ### Fixed
 - **IDA MCP HTTP stall** — `run-supervisor.py` patches stock `idalib_supervisor` onto `ThreadingHTTPServer` and accepts Streamable HTTP GET `/mcp` (patch failure is skipped, supervisor still starts). Keep-alive deadlock is **time since last healthy `tools/list`**, not process `CreationDate`; `open.ps1` holds `opening.lock` so in-flight opens are never `-Force`d. New `recover.ps1` is an immediate `-Force` path. Never `taskkill`s `ida.exe`.

--- a/skills/tests/routing-benchmark.json
+++ b/skills/tests/routing-benchmark.json
@@ -847,6 +847,21 @@
       "quick": true
     },
     {
+      "hint": "案件审查 证据链 可追溯性",
+      "expect": "R40",
+      "quick": false
+    },
+    {
+      "hint": "案例审计 证据图 可追溯性 fixity 校验",
+      "expect": "R40",
+      "quick": false
+    },
+    {
+      "hint": "evidence graph fixity check for the case audit",
+      "expect": "R40",
+      "quick": false
+    },
+    {
       "hint": "Collect public X and Twitter posts about this IOC for OSINT threat intelligence",
       "expect": "R44",
       "quick": true


### PR DESCRIPTION
R40 (case-evidence-review) was the least-covered route: a single English case in an explicitly bilingual suite, leaving its Chinese keyword set (证据链/证据图/可追溯性/案件审查/案例审计) and several English branches (evidence.?graph, fixity.?check, case.?audit) with no regression protection. Adds three cases (1 -> 4) covering those untested branches. Each new case was verified to route to R40 through both the PowerShell (master-route.ps1) and Bash (master-route.sh) routers. Full PowerShell benchmark passes 178/178 and verify-routing-coherence reports 178 cases green.